### PR TITLE
Transparent button update

### DIFF
--- a/dashing.css
+++ b/dashing.css
@@ -1,2 +1,4240 @@
-﻿@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600);html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}article,aside,details,figcaption,figure,footer,header,hgroup,main,menu,nav,section,summary{display:block}audio,canvas,progress,video{display:inline-block;vertical-align:baseline}audio:not([controls]){display:none;height:0}[hidden],template{display:none}a{background-color:transparent}a:active,a:hover{outline:0}abbr[title]{border-bottom:1px dotted}b,strong{font-weight:bold}dfn{font-style:italic}h1{font-size:2em;margin:0.67em 0}mark{background:#ff0;color:#000}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:1em 40px}hr{box-sizing:content-box;height:0}pre{overflow:auto}code,kbd,pre,samp{font-family:monospace, monospace;font-size:1em}button,input,optgroup,select,textarea{color:inherit;font:inherit;margin:0}button{overflow:visible}button,select{text-transform:none}button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}button[disabled],html input[disabled]{cursor:default}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}input{line-height:normal}input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}input[type="number"]::-webkit-inner-spin-button,input[type="number"]::-webkit-outer-spin-button{height:auto}input[type="search"]{-webkit-appearance:textfield;box-sizing:content-box}input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}fieldset{border:1px solid #c0c0c0;margin:0 2px;padding:0.35em 0.625em 0.75em}legend{border:0;padding:0}textarea{overflow:auto}optgroup{font-weight:bold}table{border-collapse:collapse;border-spacing:0}td,th{padding:0}.tooltipster-base{display:flex;pointer-events:none;position:absolute}.tooltipster-box{flex:1 1 auto}.tooltipster-content{box-sizing:border-box;max-height:100%;max-width:100%;overflow:auto}.tooltipster-ruler{bottom:0;left:0;overflow:hidden;position:fixed;right:0;top:0;visibility:hidden}.tooltipster-fade{opacity:0;-webkit-transition-property:opacity;-moz-transition-property:opacity;-o-transition-property:opacity;-ms-transition-property:opacity;transition-property:opacity}.tooltipster-fade.tooltipster-show{opacity:1}.tooltipster-grow{-webkit-transform:scale(0, 0);-moz-transform:scale(0, 0);-o-transform:scale(0, 0);-ms-transform:scale(0, 0);transform:scale(0, 0);-webkit-transition-property:-webkit-transform;-moz-transition-property:-moz-transform;-o-transition-property:-o-transform;-ms-transition-property:-ms-transform;transition-property:transform;-webkit-backface-visibility:hidden}.tooltipster-grow.tooltipster-show{-webkit-transform:scale(1, 1);-moz-transform:scale(1, 1);-o-transform:scale(1, 1);-ms-transform:scale(1, 1);transform:scale(1, 1);-webkit-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1);-webkit-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);-moz-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);-ms-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);-o-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15)}.tooltipster-swing{opacity:0;-webkit-transform:rotateZ(4deg);-moz-transform:rotateZ(4deg);-o-transform:rotateZ(4deg);-ms-transform:rotateZ(4deg);transform:rotateZ(4deg);-webkit-transition-property:-webkit-transform, opacity;-moz-transition-property:-moz-transform;-o-transition-property:-o-transform;-ms-transition-property:-ms-transform;transition-property:transform}.tooltipster-swing.tooltipster-show{opacity:1;-webkit-transform:rotateZ(0deg);-moz-transform:rotateZ(0deg);-o-transform:rotateZ(0deg);-ms-transform:rotateZ(0deg);transform:rotateZ(0deg);-webkit-transition-timing-function:cubic-bezier(0.23, 0.635, 0.495, 1);-webkit-transition-timing-function:cubic-bezier(0.23, 0.635, 0.495, 2.4);-moz-transition-timing-function:cubic-bezier(0.23, 0.635, 0.495, 2.4);-ms-transition-timing-function:cubic-bezier(0.23, 0.635, 0.495, 2.4);-o-transition-timing-function:cubic-bezier(0.23, 0.635, 0.495, 2.4);transition-timing-function:cubic-bezier(0.23, 0.635, 0.495, 2.4)}.tooltipster-fall{-webkit-transition-property:top;-moz-transition-property:top;-o-transition-property:top;-ms-transition-property:top;transition-property:top;-webkit-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1);-webkit-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);-moz-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);-ms-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);-o-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15)}.tooltipster-fall.tooltipster-initial{top:0 !important}.tooltipster-fall.tooltipster-dying{-webkit-transition-property:all;-moz-transition-property:all;-o-transition-property:all;-ms-transition-property:all;transition-property:all;top:0 !important;opacity:0}.tooltipster-slide{-webkit-transition-property:left;-moz-transition-property:left;-o-transition-property:left;-ms-transition-property:left;transition-property:left;-webkit-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1);-webkit-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);-moz-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);-ms-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);-o-transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15);transition-timing-function:cubic-bezier(0.175, 0.885, 0.32, 1.15)}.tooltipster-slide.tooltipster-initial{left:-40px !important}.tooltipster-slide.tooltipster-dying{-webkit-transition-property:all;-moz-transition-property:all;-o-transition-property:all;-ms-transition-property:all;transition-property:all;left:0 !important;opacity:0}@keyframes tooltipster-fading{0%{opacity:0}100%{opacity:1}}.tooltipster-update-fade{animation:tooltipster-fading 400ms}@keyframes tooltipster-rotating{25%{transform:rotate(-2deg)}75%{transform:rotate(2deg)}100%{transform:rotate(0)}}.tooltipster-update-rotate{animation:tooltipster-rotating 600ms}@keyframes tooltipster-scaling{50%{transform:scale(1.1)}100%{transform:scale(1)}}.tooltipster-update-scale{animation:tooltipster-scaling 600ms}.tooltipster-sidetip .tooltipster-box{background:#565656;border:2px solid black;border-radius:4px}.tooltipster-sidetip.tooltipster-bottom .tooltipster-box{margin-top:8px}.tooltipster-sidetip.tooltipster-left .tooltipster-box{margin-right:8px}.tooltipster-sidetip.tooltipster-right .tooltipster-box{margin-left:8px}.tooltipster-sidetip.tooltipster-top .tooltipster-box{margin-bottom:8px}.tooltipster-sidetip .tooltipster-content{color:white;line-height:18px;padding:6px 14px}.tooltipster-sidetip .tooltipster-arrow{overflow:hidden;position:absolute}.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow{height:10px;margin-left:-10px;top:0;width:20px}.tooltipster-sidetip.tooltipster-left .tooltipster-arrow{height:20px;margin-top:-10px;right:0;top:0;width:10px}.tooltipster-sidetip.tooltipster-right .tooltipster-arrow{height:20px;margin-top:-10px;left:0;top:0;width:10px}.tooltipster-sidetip.tooltipster-top .tooltipster-arrow{bottom:0;height:10px;margin-left:-10px;width:20px}.tooltipster-sidetip .tooltipster-arrow-background,.tooltipster-sidetip .tooltipster-arrow-border{height:0;position:absolute;width:0}.tooltipster-sidetip .tooltipster-arrow-background{border:10px solid transparent}.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-background{border-bottom-color:#565656;left:0;top:3px}.tooltipster-sidetip.tooltipster-left .tooltipster-arrow-background{border-left-color:#565656;left:-3px;top:0}.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-background{border-right-color:#565656;left:3px;top:0}.tooltipster-sidetip.tooltipster-top .tooltipster-arrow-background{border-top-color:#565656;left:0;top:-3px}.tooltipster-sidetip .tooltipster-arrow-border{border:10px solid transparent;left:0;top:0}.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-border{border-bottom-color:black}.tooltipster-sidetip.tooltipster-left .tooltipster-arrow-border{border-left-color:black}.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-border{border-right-color:black}.tooltipster-sidetip.tooltipster-top .tooltipster-arrow-border{border-top-color:black}.tooltipster-sidetip .tooltipster-arrow-uncropped{position:relative}.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-uncropped{top:-10px}.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-uncropped{left:-10px}.tooltipster-content-changing{opacity:0.5;-webkit-transform:scale(1.1, 1.1);-moz-transform:scale(1.1, 1.1);-o-transform:scale(1.1, 1.1);-ms-transform:scale(1.1, 1.1);transform:scale(1.1, 1.1)}.tooltipster-sidetip .tooltipster-box,.tooltipster-box{background-color:#555;border-radius:10px;box-shadow:0 4px 8px rgba(0,0,0,0.3);border:none;max-width:250px;padding:0.75rem;border-radius:10px;overflow:hidden}.tooltipster-sidetip .tooltipster-box .tooltipster-content,.tooltipster-box .tooltipster-content{font-weight:600;font-size:0.9rem;line-height:1.1rem;padding:0;overflow:hidden}.tooltipster-sidetip.tooltipster-top .tooltipster-arrow-border,.tooltipster-sidetip.tooltipster-top .tooltipster-arrow-background,.tooltipster-top .tooltipster-arrow-border,.tooltipster-top .tooltipster-arrow-background{border-top-color:#555}.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-border,.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-background,.tooltipster-bottom .tooltipster-arrow-border,.tooltipster-bottom .tooltipster-arrow-background{border-bottom-color:#555}.tooltipster-sidetip.tooltipster-left .tooltipster-arrow-border,.tooltipster-sidetip.tooltipster-left .tooltipster-arrow-background,.tooltipster-left .tooltipster-arrow-border,.tooltipster-left .tooltipster-arrow-background{border-left-color:#555}.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-border,.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-background,.tooltipster-right .tooltipster-arrow-border,.tooltipster-right .tooltipster-arrow-background{border-right-color:#555}.tooltip-templates{display:none}.clippy-theme .tooltipster-box{background-color:#FFF;border-radius:5px !important;box-shadow:0 4px 8px rgba(0,0,0,0.2);border:2px solid #D4D4D4;max-width:350px;padding:1rem;border-radius:10px}.clippy-theme .tooltipster-box .tooltipster-content{font-weight:400;font-size:0.9rem;line-height:1.2rem;padding:0}.clippy-theme .tooltipster-box .tooltipster-content h4,.clippy-theme .tooltipster-box .tooltipster-content p{font-size:0.9rem}.clippy-theme .tooltipster-box .tooltipster-content h4{font-weight:600}.clippy-theme .tooltipster-box .tooltipster-content p{margin-bottom:0}.clippy-theme .tooltipster-box .tooltipster-content .button,.clippy-theme .tooltipster-box .tooltipster-content .file-custom .file-custom--button,.file-custom .clippy-theme .tooltipster-box .tooltipster-content .file-custom--button{margin-top:0.5rem}.clippy-theme.tooltipster-top .tooltipster-arrow-border,.clippy-theme.tooltipster-top .tooltipster-arrow-background{border-top-color:transparent}.clippy-theme.tooltipster-bottom .tooltipster-arrow-border,.clippy-theme.tooltipster-bottom .tooltipster-arrow-background{border-bottom-color:transparent}.clippy-theme.tooltipster-left .tooltipster-arrow-border,.clippy-theme.tooltipster-left .tooltipster-arrow-background{border-left-color:transparent}.clippy-theme.tooltipster-right .tooltipster-arrow-border,.clippy-theme.tooltipster-right .tooltipster-arrow-background{border-right-color:transparent}.hide,.hidden,.is-hidden{display:none !important}.mobile-hide,.is-hidden_phone{display:block;display:none}@media all and (min-width: 40em){.mobile-hide,.is-hidden_phone{display:block}}.mobile-hide-inline,.is-hidden--inline_phone{display:inline;display:none}@media all and (min-width: 40em){.mobile-hide-inline,.is-hidden--inline_phone{display:inline}}.tablet-hide,.is-hidden_tablet{display:block}@media all and (min-width: 40em){.tablet-hide,.is-hidden_tablet{display:none}}@media all and (min-width: 64em){.tablet-hide,.is-hidden_tablet{display:block}}.tablet-hide-inline,.is-hidden--inline_tablet{display:inline}@media all and (min-width: 40em){.tablet-hide-inline,.is-hidden--inline_tablet{display:none}}@media all and (min-width: 64em){.tablet-hide-inline,.is-hidden--inline_tablet{display:inline}}@media all and (min-width: 64em){.desktop-hide,.is-hidden_desktop{display:none}}.pointer,.selectable{cursor:pointer !important}.remove-margin,.no-margin{margin:0 !important}.remove-margin--top,.no-margin--top{margin-top:0 !important}.remove-margin--right,.no-margin--right{margin-right:0 !important}.remove-margin--bottom,.no-margin--bottom{margin-bottom:0 !important}.remove-margin--left,.no-margin--left{margin-left:0 !important}.remove-padding,.no-padding{padding:0 !important}.remove-padding--top,.no-padding--top{padding-top:0 !important}.remove-padding--right,.no-padding--right{padding-right:0 !important}.remove-padding--bottom,.no-padding--bottom{padding-bottom:0 !important}.remove-padding--left,.no-padding--left{padding-left:0 !important}.remove-border{border:none !important}.float-left{float:left !important}.float-right{float:right !important}.float-none{float:none !important}.fixed{position:fixed !important}.relative{position:relative !important}.text-color--white{color:#fff}.text-color--black{color:#000}.text-color--gray,.text-color--grey{color:#6E6E6E}.text-color--blue{color:#3F70C9}.text-color--green{color:#09AA66}.text-color--orange{color:#FFA11F}.text-color--purple{color:#9F65AE}.text-color--red{color:#DA3D30}.text-color--yellow{color:#F2E670}.row,.app-menu .app-navigation{overflow:auto}.app-menu .app-navigation{margin:0;padding:0;list-style:none}.button--icon.button--icon--main:active{-webkit-box-shadow:0 2px 4px rgba(0,0,0,0.5);-moz-box-shadow:0 2px 4px rgba(0,0,0,0.5);box-shadow:0 2px 4px rgba(0,0,0,0.5)}.button--icon.button--icon--main,.card.is-selectable:hover{-webkit-box-shadow:0 4px 8px rgba(0,0,0,0.3);-moz-box-shadow:0 4px 8px rgba(0,0,0,0.3);box-shadow:0 4px 8px rgba(0,0,0,0.3)}.button,.file-custom .file-custom--button,button,input[type='submit'],input[type='reset'],.button.button--round,button.button--round,input[type='submit'].button--round,input[type='reset'].button--round{border-radius:50px}.button.button--smooth,.file-custom .button--smooth.file-custom--button,.file-custom .app-menu .app-context .app-title .file-custom--button.button--navigation,.app-menu .app-context .app-title .file-custom .file-custom--button.button--navigation,.app-menu .app-context .app-title .button.button--navigation,button.button--smooth,.app-menu .app-context .app-title button.button--navigation,input[type='submit'].button--smooth,.app-menu .app-context .app-title input[type='submit'].button--navigation,input[type='reset'].button--smooth,.app-menu .app-context .app-title input[type='reset'].button--navigation,.page-banner .button--banner{border-radius:5px}.button.button--square,.file-custom .button--square.file-custom--button,button.button--square,input[type='submit'].button--square,input[type='reset'].button--square{border-radius:0}hr{border:0;border-top:2px solid #D4D4D4}.dashing-app{-webkit-overflow-scrolling:touch;overflow:auto;position:absolute;width:100%;height:100%}.text-align-center,.center-align,.align-center{text-align:center !important}.text-align-left,.left-align,.align-left{text-align:left !important}.text-align-right,.right-align,.align-right{text-align:right !important}.no-wrap{text-overflow:ellipsis;white-space:nowrap;overflow:hidden}.break-word{word-wrap:break-word}*{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}body{background-color:#EDEDED;font-family:"Source Sans Pro",sans-serif;font-size:1rem}h1,h2,h3,h4,h5,h6{color:#222;font-family:"Source Sans Pro",sans-serif;font-weight:600;margin:0}h1,.font-size--xlarge{font-size:1.953rem}h2,.font-size--large{font-size:1.563rem}h3,.font-size--medium{font-size:1.25rem}h4,.font-size--normal{font-size:1rem}small,.font-size--small{font-size:.9rem}.font-size--xsmall{font-size:.8rem}a{color:#3F70C9;cursor:pointer;font-weight:600;outline:none;text-decoration:none}a:hover,a:focus{color:#84A7ED}p{color:#222;color:#24292C;font-size:1rem;line-height:1.25rem}strong,.strong{font-weight:600}*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}html{font-size:100%}@media all and (min-width: 40em){html{font-size:105%}}@media all and (min-width: 64em){html{font-size:110%}}.row{margin:auto;max-width:1200px;padding-left:1rem;width:100%}.row.row--nested{padding-left:0}.column{padding:1rem;padding-left:0 !important}.column.column--nested{padding-top:calc((1rem) / 2);padding-bottom:calc((1rem) / 2)}@media all and (max-width: 40em){.column.column--nested{padding-right:0}}@media all and (min-width: 40em){.column.column--nested:last-of-type{padding-right:0}}.column.column--full,.column.column--three-fourths,.column.column--two-thirds,.column.column--half,.column.column--third,.column.column--fourth,.column.column--sixth,.column.column--eighth{width:100%}@media all and (min-width: 40em){.column{float:left}.column.flow-opposite{float:right}.column.column--full{float:none;width:100%}.column.column--three-fourths{width:75%}.column.column--two-thirds{width:66.666%}.column.column--half{width:50%}.column.column--third{width:33.333%}.column.column--fourth{width:25%}.column.column--sixth{width:16.666%}.column.column--eighth{width:12.5%}}.row-flex{display:-webkit-flex;display:-moz-box;display:-ms-flexbox;display:flex}.row-flex .column-flex{-webkit-flex:1;-moz-box-flex:1;flex:1;margin:1rem}.grid{grid-template-columns:repeat(12, 1fr)}@media all and (min-width: 40em){.grid .grid--full{width:calc(100% - 1rem);float:left}}@media all and (min-width: 40em){.grid .grid--five-sixths{width:calc(83.3333% - 1rem);float:left}}@media all and (min-width: 40em){.grid .grid--three-fourths{width:calc(75% - 1rem);float:left}}@media all and (min-width: 40em){.grid .grid--two-thirds{width:calc(66.6666% - 1rem);float:left}}@media all and (min-width: 40em){.grid .grid--half{width:calc(50% - 1rem);float:left}}@media all and (min-width: 40em){.grid .grid--third{width:calc(33.3333% - 1rem);float:left}}@media all and (min-width: 40em){.grid .grid--fourth{width:calc(25% - 1rem);float:left}}@media all and (min-width: 40em){.grid .grid--sixth{width:calc(16.6666% - 1rem);float:left}}.grid .grid--full,.grid .grid--half,.grid .grid--three-fourths,.grid .grid--fourth,.grid .grid--two-thirds,.grid .grid--five-sixths,.grid .grid--third,.grid .grid--sixth{margin:1rem 0}.grid .grid--full:first-of-type,.grid .grid--half:first-of-type,.grid .grid--three-fourths:first-of-type,.grid .grid--fourth:first-of-type,.grid .grid--two-thirds:first-of-type,.grid .grid--five-sixths:first-of-type,.grid .grid--third:first-of-type,.grid .grid--sixth:first-of-type{margin-top:0}.grid .grid--full:last-of-type,.grid .grid--half:last-of-type,.grid .grid--three-fourths:last-of-type,.grid .grid--fourth:last-of-type,.grid .grid--two-thirds:last-of-type,.grid .grid--five-sixths:last-of-type,.grid .grid--third:last-of-type,.grid .grid--sixth:last-of-type{margin-bottom:0}@media all and (min-width: 40em){.grid .grid--full,.grid .grid--half,.grid .grid--three-fourths,.grid .grid--fourth,.grid .grid--two-thirds,.grid .grid--five-sixths,.grid .grid--third,.grid .grid--sixth{margin:calc(1rem / 2)}.grid .grid--full:first-of-type,.grid .grid--half:first-of-type,.grid .grid--three-fourths:first-of-type,.grid .grid--fourth:first-of-type,.grid .grid--two-thirds:first-of-type,.grid .grid--five-sixths:first-of-type,.grid .grid--third:first-of-type,.grid .grid--sixth:first-of-type{margin:calc(1rem / 2)}.grid .grid--full:last-of-type,.grid .grid--half:last-of-type,.grid .grid--three-fourths:last-of-type,.grid .grid--fourth:last-of-type,.grid .grid--two-thirds:last-of-type,.grid .grid--five-sixths:last-of-type,.grid .grid--third:last-of-type,.grid .grid--sixth:last-of-type{margin:calc(1rem / 2)}}@supports (display: grid){.grid .grid--full,.grid .grid--half,.grid .grid--three-fourths,.grid .grid--fourth,.grid .grid--two-thirds,.grid .grid--five-sixths,.grid .grid--third,.grid .grid--sixth{margin:0}.grid .grid--full:first-of-type,.grid .grid--half:first-of-type,.grid .grid--three-fourths:first-of-type,.grid .grid--fourth:first-of-type,.grid .grid--two-thirds:first-of-type,.grid .grid--five-sixths:first-of-type,.grid .grid--third:first-of-type,.grid .grid--sixth:first-of-type{margin:0}.grid .grid--full:last-of-type,.grid .grid--half:last-of-type,.grid .grid--three-fourths:last-of-type,.grid .grid--fourth:last-of-type,.grid .grid--two-thirds:last-of-type,.grid .grid--five-sixths:last-of-type,.grid .grid--third:last-of-type,.grid .grid--sixth:last-of-type{margin:0}}.grid-align-center{align-items:center}.grid-align-top{align-items:start}.grid-align-bottom{align-items:end}.grid-justify-center{justify-items:center}.grid-justify-left{justify-items:start}.grid-justify-right{justify-items:end}.grid-wrapper{max-width:1200px;margin:auto;width:100%}@supports (display: grid){.grid-layout,.grid-padding{padding:1rem}}.grid{display:block;overflow:auto;grid-template-columns:repeat(12, 1fr)}@supports (display: grid){.grid{display:grid;grid-gap:1rem}}@supports (display: grid){.grid *{grid-column:1 / -1}@media all and (min-width: 40em){.grid *{grid-column:span 12}@supports (display: grid){.grid *{width:auto}}}}.grid .grid--full{grid-column:1 / -1}@media all and (min-width: 40em){.grid .grid--full{grid-column:span 12}@supports (display: grid){.grid .grid--full{width:auto}}}.grid .grid--five-sixths{grid-column:1 / -1}@media all and (min-width: 40em){.grid .grid--five-sixths{grid-column:span 10}@supports (display: grid){.grid .grid--five-sixths{width:auto}}}.grid .grid--three-fourths{grid-column:1 / -1}@media all and (min-width: 40em){.grid .grid--three-fourths{grid-column:span 9}@supports (display: grid){.grid .grid--three-fourths{width:auto}}}.grid .grid--two-thirds{grid-column:1 / -1}@media all and (min-width: 40em){.grid .grid--two-thirds{grid-column:span 8}@supports (display: grid){.grid .grid--two-thirds{width:auto}}}.grid .grid--half{grid-column:1 / -1}@media all and (min-width: 40em){.grid .grid--half{grid-column:span 6}@supports (display: grid){.grid .grid--half{width:auto}}}.grid .grid--third{grid-column:1 / -1}@media all and (min-width: 40em){.grid .grid--third{grid-column:span 4}@supports (display: grid){.grid .grid--third{width:auto}}}.grid .grid--fourth{grid-column:1 / -1}@media all and (min-width: 40em){.grid .grid--fourth{grid-column:span 3}@supports (display: grid){.grid .grid--fourth{width:auto}}}.grid .grid--sixth{grid-column:1 / -1}@media all and (min-width: 40em){.grid .grid--sixth{grid-column:span 2}@supports (display: grid){.grid .grid--sixth{width:auto}}}.grid .card{margin:0}fieldset{border:none;padding:0;margin:0}fieldset label{display:block;font-size:.8rem;font-weight:600;margin-bottom:0.3rem;text-align:left}fieldset label.inline{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;font-size:1rem;display:inline-block;font-weight:normal;cursor:pointer}fieldset select,fieldset textarea,fieldset input[type="date"],fieldset input[type="time"],fieldset input[type="email"],fieldset input[type="month"],fieldset input[type="number"],fieldset input[type="password"],fieldset input[type="tel"],fieldset input[type="text"]{-webkit-appearance:none;-moz-appearance:none;background-color:#fff;border:2px solid #E0E0E0;border-radius:5px;font-size:1rem;max-width:100%;padding:0.6rem;width:100%}fieldset select:focus,fieldset textarea:focus,fieldset input[type="date"]:focus,fieldset input[type="time"]:focus,fieldset input[type="email"]:focus,fieldset input[type="month"]:focus,fieldset input[type="number"]:focus,fieldset input[type="password"]:focus,fieldset input[type="tel"]:focus,fieldset input[type="text"]:focus{border-color:#3F70C9;outline-color:transparent;outline-style:none}fieldset select[disabled],fieldset textarea[disabled],fieldset input[type="date"][disabled],fieldset input[type="time"][disabled],fieldset input[type="email"][disabled],fieldset input[type="month"][disabled],fieldset input[type="number"][disabled],fieldset input[type="password"][disabled],fieldset input[type="tel"][disabled],fieldset input[type="text"][disabled]{background-color:#EDEDED !important;border-color:#EDEDED !important;cursor:default !important}fieldset input[type="date"],fieldset input[type="time"],fieldset input[type="month"]{min-height:2.75rem}fieldset input[type=checkbox],fieldset input[type=radio]{float:left;margin-top:0.3rem;margin-right:0.5rem}fieldset textarea{resize:vertical}fieldset select{cursor:pointer}fieldset .input--add-on{display:flex}fieldset .input--add-on .add-on--field,fieldset .input--add-on .add-on--before,fieldset .input--add-on .add-on--after{width:5rem;flex-grow:1}@media all and (min-width: 40em){fieldset .input--add-on .add-on--field,fieldset .input--add-on .add-on--before,fieldset .input--add-on .add-on--after{width:auto}}fieldset .input--add-on .add-on--field,fieldset .input--add-on .add-on--before{border-radius:5px 0 0 5px;border-right:none}fieldset .input--add-on .add-on--after{border-radius:0 5px 5px 0}fieldset .input--add-on select.add-on--after,fieldset .input--add-on select.add-on--before{padding-right:2rem;flex:none}fieldset .input--add-on .add-on--button{border-radius:0 5px 5px 0 !important;padding-top:calc(0.6rem + 3px);padding-bottom:calc(0.6rem + 3px);margin:0}fieldset .input--add-on .add-on--button.button--border{background-color:rgba(255,255,255,0);border-color:#E0E0E0;color:#E0E0E0;color:#878787}fieldset .input--add-on .add-on--button.button--border .dashing-icon:before,fieldset .input--add-on .add-on--button.button--border i.dashing-tooltip:before,fieldset .input--add-on .add-on--button.button--border i.dashing-clippy:before,fieldset .input--add-on .add-on--button.button--border .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title fieldset .input--add-on .add-on--button.button--border .button--navigation:before{color:#E0E0E0}fieldset .input--add-on .add-on--button.button--border:hover,fieldset .input--add-on .add-on--button.button--border:focus{background-color:#c7c7c7;border-color:rgba(255,255,255,0);color:#fff}fieldset .input--add-on .add-on--button.button--border:hover .dashing-icon:before,fieldset .input--add-on .add-on--button.button--border:hover i.dashing-tooltip:before,fieldset .input--add-on .add-on--button.button--border:hover i.dashing-clippy:before,fieldset .input--add-on .add-on--button.button--border:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title fieldset .input--add-on .add-on--button.button--border:hover .button--navigation:before,fieldset .input--add-on .add-on--button.button--border:focus .dashing-icon:before,fieldset .input--add-on .add-on--button.button--border:focus i.dashing-tooltip:before,fieldset .input--add-on .add-on--button.button--border:focus i.dashing-clippy:before,fieldset .input--add-on .add-on--button.button--border:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title fieldset .input--add-on .add-on--button.button--border:focus .button--navigation:before{color:#fff;transition:all 50ms ease-in-out}fieldset .input--add-on .add-on--button.button--border:active{background-color:#bababa}fieldset .input--add-on .add-on--button.button--border .dashing-icon:before,fieldset .input--add-on .add-on--button.button--border i.dashing-tooltip:before,fieldset .input--add-on .add-on--button.button--border i.dashing-clippy:before,fieldset .input--add-on .add-on--button.button--border .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title fieldset .input--add-on .add-on--button.button--border .button--navigation:before{color:#878787}fieldset.select--has-icon,fieldset .select--has-icon{position:relative}fieldset.select--has-icon:after,fieldset .select--has-icon:after{content:'\e800';color:#A1A1A1;font-family:'dashing-icons';font-size:12px;font-weight:600;pointer-events:none;position:absolute;right:2rem;bottom:calc(1rem * 2)}fieldset.select--has-icon.has-error:after,fieldset .select--has-icon.has-error:after{color:#F76553}fieldset.select--has-icon.has-warning:after,fieldset .select--has-icon.has-warning:after{color:#F7AD4B}fieldset.select--has-icon.column--nested:after,fieldset .select--has-icon.column--nested:after{right:1.5rem;bottom:1.5rem}@media all and (min-width: 40em){fieldset.select--has-icon.column--nested:last-of-type:after,fieldset .select--has-icon.column--nested:last-of-type:after{right:0.5rem}}fieldset.select--has-icon select::-ms-expand,fieldset .select--has-icon select::-ms-expand{display:none}fieldset .message{color:#6E6E6E;list-style:none;margin:0;margin-top:0.4rem;overflow:auto;padding:0}fieldset .message li{float:left;font-size:1rem;margin-right:0.5rem}fieldset.has-error label,fieldset.has-error select,fieldset.has-error textarea,fieldset.has-error input[type="date"],fieldset.has-error input[type="time"],fieldset.has-error input[type="email"],fieldset.has-error input[type="month"],fieldset.has-error input[type="number"],fieldset.has-error input[type="password"],fieldset.has-error input[type="tel"],fieldset.has-error input[type="text"],fieldset .has-error label,fieldset .has-error select,fieldset .has-error textarea,fieldset .has-error input[type="date"],fieldset .has-error input[type="time"],fieldset .has-error input[type="email"],fieldset .has-error input[type="month"],fieldset .has-error input[type="number"],fieldset .has-error input[type="password"],fieldset .has-error input[type="tel"],fieldset .has-error input[type="text"]{color:#DA3D30;border-color:#FF9886}fieldset.has-error select:focus,fieldset.has-error textarea:focus,fieldset.has-error input[type="date"]:focus,fieldset.has-error input[type="time"]:focus,fieldset.has-error input[type="email"]:focus,fieldset.has-error input[type="month"]:focus,fieldset.has-error input[type="number"]:focus,fieldset.has-error input[type="password"]:focus,fieldset.has-error input[type="tel"]:focus,fieldset.has-error input[type="text"]:focus,fieldset .has-error select:focus,fieldset .has-error textarea:focus,fieldset .has-error input[type="date"]:focus,fieldset .has-error input[type="time"]:focus,fieldset .has-error input[type="email"]:focus,fieldset .has-error input[type="month"]:focus,fieldset .has-error input[type="number"]:focus,fieldset .has-error input[type="password"]:focus,fieldset .has-error input[type="tel"]:focus,fieldset .has-error input[type="text"]:focus{border-color:#DA3D30}fieldset.has-error .message li,fieldset .has-error .message li{color:#DA3D30}fieldset.has-warning label,fieldset.has-warning select,fieldset.has-warning textarea,fieldset.has-warning input[type="date"],fieldset.has-warning input[type="time"],fieldset.has-warning input[type="email"],fieldset.has-warning input[type="month"],fieldset.has-warning input[type="number"],fieldset.has-warning input[type="password"],fieldset.has-warning input[type="tel"],fieldset.has-warning input[type="text"],fieldset .has-warning label,fieldset .has-warning select,fieldset .has-warning textarea,fieldset .has-warning input[type="date"],fieldset .has-warning input[type="time"],fieldset .has-warning input[type="email"],fieldset .has-warning input[type="month"],fieldset .has-warning input[type="number"],fieldset .has-warning input[type="password"],fieldset .has-warning input[type="tel"],fieldset .has-warning input[type="text"]{color:#FFA11F;border-color:#FFC664}fieldset.has-warning select:focus,fieldset.has-warning textarea:focus,fieldset.has-warning input[type="date"]:focus,fieldset.has-warning input[type="time"]:focus,fieldset.has-warning input[type="email"]:focus,fieldset.has-warning input[type="month"]:focus,fieldset.has-warning input[type="number"]:focus,fieldset.has-warning input[type="password"]:focus,fieldset.has-warning input[type="tel"]:focus,fieldset.has-warning input[type="text"]:focus,fieldset .has-warning select:focus,fieldset .has-warning textarea:focus,fieldset .has-warning input[type="date"]:focus,fieldset .has-warning input[type="time"]:focus,fieldset .has-warning input[type="email"]:focus,fieldset .has-warning input[type="month"]:focus,fieldset .has-warning input[type="number"]:focus,fieldset .has-warning input[type="password"]:focus,fieldset .has-warning input[type="tel"]:focus,fieldset .has-warning input[type="text"]:focus{border-color:#FFA11F}fieldset.has-warning .message li,fieldset .has-warning .message li{color:#FFA11F}.checkbox--custom,.checkbox-card,.radio--custom,.radio-card{display:flex}.checkbox--custom input,.checkbox-card input,.radio--custom input,.radio-card input{opacity:0;position:absolute;z-index:-1}.checkbox--custom label,.checkbox-card label,.radio--custom label,.radio-card label{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;align-items:baseline;cursor:pointer;display:inline-block;font-size:1rem;font-weight:normal;margin:0.2rem 0}@supports (display: flex){.checkbox--custom label,.checkbox-card label,.radio--custom label,.radio-card label{display:flex}}.checkbox--custom label:before,.checkbox-card label:before,.radio--custom label:before,.radio-card label:before{border:2px solid #D4D4D4;display:inline-block;color:transparent;height:20px;width:20px;margin-right:0.5rem}.checkbox--custom.inline,.inline.checkbox-card,.radio--custom.inline,.inline.radio-card{display:inline-block;margin-right:1rem}.checkbox--custom.inline .label:before,.inline.checkbox-card .label:before,.radio--custom.inline .label:before,.inline.radio-card .label:before{display:inline-block}.checkbox--custom label:before,.checkbox-card label:before{content:'\e835';border-radius:5px;font-family:'dashing-icons';font-size:12px;padding:2px}@media all and (max-width: 40em){.checkbox--custom,.checkbox-card{margin:0.2rem 0 0 0}.checkbox--custom label:not(.card),.checkbox-card label:not(.card){margin:0.4rem 0 0.25rem 0}.checkbox--custom label:not(.card):before,.checkbox-card label:not(.card):before{border-radius:8px;font-size:16px;height:32px;width:32px;margin-top:2px;margin-right:0.5rem;padding:6px}}.checkbox--custom.inline label:before,.inline.checkbox-card label:before{margin-right:0.3rem}.checkbox--custom input:hover ~ label,.checkbox-card input:hover ~ label{color:rgba(0,0,0,0.6)}.checkbox--custom input:hover ~ label:before,.checkbox-card input:hover ~ label:before{color:#D4D4D4}.checkbox--custom input:checked ~ label:before,.checkbox-card input:checked ~ label:before,.checkbox--custom input:active ~ label:before,.checkbox-card input:active ~ label:before{color:#fff;background-color:#3F70C9;border:2px solid #3F70C9}.checkbox--custom input:focus ~ label:before,.checkbox-card input:focus ~ label:before{box-shadow:0 0 0 2px #9DC0FF}.checkbox--custom input[disabled] ~ label,.checkbox-card input[disabled] ~ label,.checkbox--custom input[disabled]:active ~ label,.checkbox-card input[disabled]:active ~ label,.checkbox--custom input[disabled]:checked ~ label,.checkbox-card input[disabled]:checked ~ label{cursor:default;pointer-events:none}.checkbox--custom input[disabled] ~ label:before,.checkbox-card input[disabled] ~ label:before,.checkbox--custom input[disabled]:active ~ label:before,.checkbox-card input[disabled]:active ~ label:before,.checkbox--custom input[disabled]:checked ~ label:before,.checkbox-card input[disabled]:checked ~ label:before{border-color:#E0E0E0;background-color:#E0E0E0}.checkbox--custom input[disabled]:active ~ label:before,.checkbox-card input[disabled]:active ~ label:before,.checkbox--custom input[disabled]:checked ~ label:before,.checkbox-card input[disabled]:checked ~ label:before{color:#878787}.checkbox--custom.has-error label:before,.has-error.checkbox-card label:before,.has-error .checkbox--custom label:before,.has-error .checkbox-card label:before{border:2px solid #F76553}.checkbox--custom.has-error input:hover ~ label,.has-error.checkbox-card input:hover ~ label,.has-error .checkbox--custom input:hover ~ label,.has-error .checkbox-card input:hover ~ label{color:rgba(218,61,48,0.6)}.checkbox--custom.has-error input:hover ~ label:before,.has-error.checkbox-card input:hover ~ label:before,.has-error .checkbox--custom input:hover ~ label:before,.has-error .checkbox-card input:hover ~ label:before{color:#FF9886}.checkbox--custom.has-error input:checked ~ label:before,.has-error.checkbox-card input:checked ~ label:before,.checkbox--custom.has-error input:active ~ label:before,.has-error.checkbox-card input:active ~ label:before,.has-error .checkbox--custom input:checked ~ label:before,.has-error .checkbox-card input:checked ~ label:before,.has-error .checkbox--custom input:active ~ label:before,.has-error .checkbox-card input:active ~ label:before{color:#fff;background-color:#DD4B39;border:2px solid #DD4B39}.checkbox--custom.has-error input:focus ~ label:before,.has-error.checkbox-card input:focus ~ label:before,.has-error .checkbox--custom input:focus ~ label:before,.has-error .checkbox-card input:focus ~ label:before{box-shadow:0 0 0 2px #FF9886}.checkbox--custom.has-warning label:before,.has-warning.checkbox-card label:before,.has-warning .checkbox--custom label:before,.has-warning .checkbox-card label:before{border:2px solid #F7AD4B}.checkbox--custom.has-warning input:hover ~ label,.has-warning.checkbox-card input:hover ~ label,.has-warning .checkbox--custom input:hover ~ label,.has-warning .checkbox-card input:hover ~ label{color:rgba(255,161,31,0.6)}.checkbox--custom.has-warning input:hover ~ label:before,.has-warning.checkbox-card input:hover ~ label:before,.has-warning .checkbox--custom input:hover ~ label:before,.has-warning .checkbox-card input:hover ~ label:before{color:#FFC664}.checkbox--custom.has-warning input:checked ~ label:before,.has-warning.checkbox-card input:checked ~ label:before,.checkbox--custom.has-warning input:active ~ label:before,.has-warning.checkbox-card input:active ~ label:before,.has-warning .checkbox--custom input:checked ~ label:before,.has-warning .checkbox-card input:checked ~ label:before,.has-warning .checkbox--custom input:active ~ label:before,.has-warning .checkbox-card input:active ~ label:before{color:#fff;background-color:#F7AD4B;border:2px solid #F7AD4B}.checkbox--custom.has-warning input:focus ~ label:before,.has-warning.checkbox-card input:focus ~ label:before,.has-warning .checkbox--custom input:focus ~ label:before,.has-warning .checkbox-card input:focus ~ label:before{box-shadow:0 0 0 2px #FFE07E}.radio--custom label:before,.radio-card label:before{content:'•';border-radius:50px;font-size:1.7rem;line-height:12px;padding:0 4px}@media all and (min-width: 40em){.radio--custom label:before,.radio-card label:before{font-size:1.5rem}}@media all and (max-width: 40em){.radio--custom label:not(.card):before,.radio-card label:not(.card):before{font-size:3rem;line-height:20px;padding:0 7px;height:32px;width:32px}}@-moz-document url-prefix(){.radio--custom label:before,.radio-card label:before{font-size:1.6rem}@media all and (max-width: 40em){.radio--custom label:not(.card):before,.radio-card label:not(.card):before{line-height:20px;padding:0 7px;font-size:3rem;height:32px;width:32px}}}.radio--custom input:hover:not(:checked) ~ label,.radio-card input:hover:not(:checked) ~ label{color:rgba(0,0,0,0.6)}.radio--custom input:hover:not(:checked) ~ label:before,.radio-card input:hover:not(:checked) ~ label:before{color:#D4D4D4}.radio--custom input:checked ~ label:before,.radio-card input:checked ~ label:before{color:#fff}.radio--custom input:checked ~ label:before,.radio-card input:checked ~ label:before{background-color:#3F70C9;border-color:#3F70C9;color:#fff}.radio--custom input:focus ~ label:before,.radio-card input:focus ~ label:before{box-shadow:0 0 0 2px #9DC0FF}.radio--custom input[disabled] ~ label,.radio-card input[disabled] ~ label,.radio--custom input[disabled]:active ~ label,.radio-card input[disabled]:active ~ label,.radio--custom input[disabled]:checked ~ label,.radio-card input[disabled]:checked ~ label{cursor:default;pointer-events:none}.radio--custom input[disabled] ~ label:before,.radio-card input[disabled] ~ label:before,.radio--custom input[disabled]:active ~ label:before,.radio-card input[disabled]:active ~ label:before,.radio--custom input[disabled]:checked ~ label:before,.radio-card input[disabled]:checked ~ label:before{border-color:#E0E0E0;background-color:#E0E0E0}.radio--custom input[disabled]:active ~ label:before,.radio-card input[disabled]:active ~ label:before,.radio--custom input[disabled]:checked ~ label:before,.radio-card input[disabled]:checked ~ label:before{color:#878787}.radio--custom.has-error label:before,.has-error.radio-card label:before,.has-error .radio--custom label:before,.has-error .radio-card label:before{border:2px solid #F76553}.radio--custom.has-error input:hover:not(:checked) ~ label,.has-error.radio-card input:hover:not(:checked) ~ label,.has-error .radio--custom input:hover:not(:checked) ~ label,.has-error .radio-card input:hover:not(:checked) ~ label{color:rgba(218,61,48,0.6)}.radio--custom.has-error input:hover:not(:checked) ~ label:before,.has-error.radio-card input:hover:not(:checked) ~ label:before,.has-error .radio--custom input:hover:not(:checked) ~ label:before,.has-error .radio-card input:hover:not(:checked) ~ label:before{color:#FF9886}.radio--custom.has-error input:checked ~ label:before,.has-error.radio-card input:checked ~ label:before,.has-error .radio--custom input:checked ~ label:before,.has-error .radio-card input:checked ~ label:before{background-color:#DD4B39;border-color:#DD4B39;color:#fff}.radio--custom.has-error input:focus ~ label:before,.has-error.radio-card input:focus ~ label:before,.has-error .radio--custom input:focus ~ label:before,.has-error .radio-card input:focus ~ label:before{box-shadow:0 0 0 2px #FF9886}.radio--custom.has-warning label:before,.has-warning.radio-card label:before,.has-warning .radio--custom label:before,.has-warning .radio-card label:before{border:2px solid #F7AD4B}.radio--custom.has-warning input:hover:not(:checked) ~ label,.has-warning.radio-card input:hover:not(:checked) ~ label,.has-warning .radio--custom input:hover:not(:checked) ~ label,.has-warning .radio-card input:hover:not(:checked) ~ label{color:rgba(255,161,31,0.6)}.radio--custom.has-warning input:hover:not(:checked) ~ label:before,.has-warning.radio-card input:hover:not(:checked) ~ label:before,.has-warning .radio--custom input:hover:not(:checked) ~ label:before,.has-warning .radio-card input:hover:not(:checked) ~ label:before{color:#FFC664}.radio--custom.has-warning input:checked ~ label:before,.has-warning.radio-card input:checked ~ label:before,.has-warning .radio--custom input:checked ~ label:before,.has-warning .radio-card input:checked ~ label:before{background-color:#F7AD4B;border-color:#F7AD4B;color:#fff}.radio--custom.has-warning input:focus ~ label:before,.has-warning.radio-card input:focus ~ label:before,.has-warning .radio--custom input:focus ~ label:before,.has-warning .radio-card input:focus ~ label:before{box-shadow:0 0 0 2px #FFE07E}.range--custom{width:10rem;margin:0 auto}.range--custom input[type="range"]{-webkit-appearance:none;-webkit-tap-highlight-color:rgba(255,255,255,0);background:none;border:none;border-radius:30px;cursor:pointer;width:100%;margin:0;min-height:2.5rem;outline:none}.range--custom input[type="range"]::-webkit-slider-runnable-track{-webkit-appearance:none;background-color:#D4D4D4;border-radius:30px;height:0.5rem}.range--custom input[type="range"]::-webkit-slider-runnable-track:active{background-color:#C7C7C7}.range--custom input[type="range"]::-moz-range-track{border:inherit;background-color:#D4D4D4;border-radius:30px;height:0.5rem}.range--custom input[type="range"]::-moz-range-track:active{background-color:#C7C7C7}.range--custom input[type=range]::-moz-focus-outer{border:0}.range--custom input[type="range"]::-ms-track{border:inherit;color:transparent;background:transparent}.range--custom input[type="range"]::-ms-fill-lower,.range--custom input[type="range"]::-ms-fill-upper{background:transparent}.range--custom input[type="range"]::-ms-tooltip{display:none}.range--custom input[type="range"]::-webkit-slider-thumb{-webkit-appearance:none;background-color:#fff;border:2px solid #D4D4D4;width:20px;height:20px;border-radius:30px;margin-top:-5px}.range--custom input[type="range"]::-moz-range-thumb{background-color:#fff;border:2px solid #D4D4D4;width:20px;height:20px;border-radius:30px}.range--custom input[type="range"]::-ms-thumb{-webkit-appearance:none;background-color:#fff;border:2px solid #D4D4D4;width:20px;height:20px}.file-custom{float:left}.file-custom .file-custom--button{display:inline-block;padding:6px 12px;cursor:pointer}.file-custom ~ input[type="file"]{display:none}.switch{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;display:inline-block;position:relative;width:50px}.switch .switch--checkbox{display:none}.switch .switch--label{border-radius:50px;background-color:#C7C7C7;cursor:pointer;display:block;height:25px;margin:0;overflow:hidden}label+.switch{top:6px;margin-left:0.2rem}.switch.switch--has-text .onoffswitch-inner:before{content:"on";padding-left:0.5rem}.switch.switch--has-text .onoffswitch-inner:after{content:"inactive";float:right;padding-right:0.5rem}.switch .switch--inner{-webkit-transition:all 0.05s ease-in 0s;-moz-transition:all 0.05s ease-in 0s;-o-transition:all 0.05s ease-in 0s;-ms-transition:all 0.05s ease-in 0s;transition:all 0.05s ease-in 0s;display:block;width:200%;margin-left:-100%}.switch .switch--inner:before,.switch .switch--inner:after{color:#fff;display:block;float:left;height:2rem;padding:0;line-height:26px;font-size:.8rem;text-transform:uppercase;width:50%}.switch .switch--inner:before{background-color:#3F70C9;content:""}.switch .switch--inner:after{background-color:#C7C7C7;content:""}.switch .switch--handle{-webkit-transition:all 0.05s ease-in 0s;-moz-transition:all 0.05s ease-in 0s;-o-transition:all 0.05s ease-in 0s;-ms-transition:all 0.05s ease-in 0s;transition:all 0.05s ease-in 0s;background-color:#fff;border-radius:50%;display:block;margin:3px;position:absolute;top:0;bottom:0;right:25px;width:19px}.switch .switch--checkbox:checked+.switch--label .switch--inner{margin-left:0}.switch .switch--checkbox:checked+.switch--label .switch--handle{right:0}.checkbox-card,.radio-card{display:inline-flex;margin-right:0.5rem}.checkbox-card .card,.radio-card .card{float:none;margin:0;padding:1rem}.checkbox-card .card:before,.radio-card .card:before{display:inline-block}.checkbox-card .card.disabled,.radio-card .card.disabled{background-color:#D4D4D4;border-color:#D4D4D4;pointer-events:none;opacity:0.4;color:#555}.checkbox-card .card.center-align,.checkbox-card .card.align-center,.radio-card .card.center-align,.radio-card .card.align-center{float:none}.checkbox-card.is-block,.checkbox-card.block,.radio-card.is-block,.radio-card.block{display:block;margin-bottom:0.5rem;width:100%}.checkbox-card input:focus ~ label:before,.radio-card input:focus ~ label:before{box-shadow:none}.checkbox-card input:focus ~ label,.radio-card input:focus ~ label{box-shadow:0 0 0 2px #9DC0FF}.checkbox-card input:checked ~ label,.checkbox-card input:active ~ label,.radio-card input:checked ~ label,.radio-card input:active ~ label{color:#3F70C9;border:2px solid #3F70C9}.checkbox-card input[disabled] ~ label,.checkbox-card input[disabled]:active ~ label,.checkbox-card input[disabled]:checked ~ label,.radio-card input[disabled] ~ label,.radio-card input[disabled]:active ~ label,.radio-card input[disabled]:checked ~ label{cursor:default;pointer-events:none}.checkbox-card input[disabled] ~ label:before,.checkbox-card input[disabled]:active ~ label:before,.checkbox-card input[disabled]:checked ~ label:before,.radio-card input[disabled] ~ label:before,.radio-card input[disabled]:active ~ label:before,.radio-card input[disabled]:checked ~ label:before{border-color:#A1A1A1 !important;background-color:#D4D4D4 !important}.checkbox-card.checkbox-card--small .card,.radio-card.checkbox-card--small .card{padding:calc(1rem / 2)}.checkbox-card.radio-card--small .card,.radio-card.radio-card--small .card{padding:calc(1rem / 2)}.radio-card .card:before{top:calc(1rem + 2px);left:1rem}.radio-card.radio-card--small .card:before{top:calc((1rem / 2) + 2px);left:calc((1rem / 2) + 3px)}.button,.file-custom .file-custom--button,button,input[type='submit'],input[type='reset'],.app-menu .app-navigation li a{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;border:none;cursor:pointer;font-size:.9rem;font-weight:600;outline:none;text-transform:uppercase;text-decoration:none;transition:all 50ms ease-in-out}.button:first-of-type,.file-custom .file-custom--button:first-of-type,button:first-of-type,input[type='submit']:first-of-type,input[type='reset']:first-of-type,.app-menu .app-navigation li a:first-of-type{margin-left:0}.button:last-of-type,.file-custom .file-custom--button:last-of-type,button:last-of-type,input[type='submit']:last-of-type,input[type='reset']:last-of-type,.app-menu .app-navigation li a:last-of-type{margin-right:0}.button:hover,.file-custom .file-custom--button:hover,button:hover,input[type='submit']:hover,input[type='reset']:hover,.app-menu .app-navigation li a:hover{transition:all .1s ease-in-out}.button,.file-custom .file-custom--button,button,input[type='submit'],input[type='reset']{background-color:#3F70C9;color:#fff;-webkit-font-smoothing:auto;font-weight:400;margin:0.05rem 0.25rem;padding:0.75rem 1rem;text-align:center}.button:hover,.file-custom .file-custom--button:hover,.button:focus,.file-custom .file-custom--button:focus,button:hover,button:focus,input[type='submit']:hover,input[type='submit']:focus,input[type='reset']:hover,input[type='reset']:focus{background-color:#2f59a6;color:#fff}.button:active,.file-custom .file-custom--button:active,button:active,input[type='submit']:active,input[type='reset']:active{background-color:#294f92}.button:not(.button--transparent) .dashing-icon:before,.file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before,.button:not(.button--transparent) i.dashing-tooltip:before,.file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button:not(.button--transparent) i.dashing-clippy:before,.file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button:not(.button--transparent) .button--navigation:before,.file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before,button:not(.button--transparent) .dashing-icon:before,button:not(.button--transparent) i.dashing-tooltip:before,button:not(.button--transparent) i.dashing-clippy:before,button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button:not(.button--transparent) .button--navigation:before,input[type='submit']:not(.button--transparent) .dashing-icon:before,input[type='submit']:not(.button--transparent) i.dashing-tooltip:before,input[type='submit']:not(.button--transparent) i.dashing-clippy:before,input[type='submit']:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit']:not(.button--transparent) .button--navigation:before,input[type='reset']:not(.button--transparent) .dashing-icon:before,input[type='reset']:not(.button--transparent) i.dashing-tooltip:before,input[type='reset']:not(.button--transparent) i.dashing-clippy:before,input[type='reset']:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset']:not(.button--transparent) .button--navigation:before{color:#fff}@media all and (min-width: 40em){.button,.file-custom .file-custom--button,button,input[type='submit'],input[type='reset']{display:inline-block;padding:0.5rem 1rem;padding-top:0.45rem}}.button[disabled],.file-custom [disabled].file-custom--button,.button.disabled,.file-custom .disabled.file-custom--button,.button.button--disabled,.file-custom .button--disabled.file-custom--button,button[disabled],button.disabled,button.button--disabled,input[type='submit'][disabled],input[type='submit'].disabled,input[type='submit'].button--disabled,input[type='reset'][disabled],input[type='reset'].disabled,input[type='reset'].button--disabled{cursor:default;opacity:0.4;pointer-events:none}.button.button-block,.file-custom .button-block.file-custom--button,button.button-block,input[type='submit'].button-block,input[type='reset'].button-block{display:block !important;width:100%}.button.button--large,.file-custom .button--large.file-custom--button,button.button--large,input[type='submit'].button--large,input[type='reset'].button--large{font-size:1.25rem !important;padding:0.6rem 1.2rem}.button.button--small,.file-custom .button--small.file-custom--button,.file-custom .app-menu .app-context .app-title .file-custom--button.button--navigation,.app-menu .app-context .app-title .file-custom .file-custom--button.button--navigation,.app-menu .app-context .app-title .button.button--navigation,button.button--small,.app-menu .app-context .app-title button.button--navigation,input[type='submit'].button--small,.app-menu .app-context .app-title input[type='submit'].button--navigation,input[type='reset'].button--small,.app-menu .app-context .app-title input[type='reset'].button--navigation{font-size:.8rem !important;padding:0.4rem 0.75rem}.button.button--primary,.file-custom .button--primary.file-custom--button,button.button--primary,input[type='submit'].button--primary,input[type='reset'].button--primary{background-color:#3F70C9;color:#fff}.button.button--primary:hover,.file-custom .button--primary.file-custom--button:hover,.button.button--primary:focus,.file-custom .button--primary.file-custom--button:focus,button.button--primary:hover,button.button--primary:focus,input[type='submit'].button--primary:hover,input[type='submit'].button--primary:focus,input[type='reset'].button--primary:hover,input[type='reset'].button--primary:focus{background-color:#2f59a6;color:#fff}.button.button--primary:active,.file-custom .button--primary.file-custom--button:active,button.button--primary:active,input[type='submit'].button--primary:active,input[type='reset'].button--primary:active{background-color:#294f92}.button.button--primary:not(.button--transparent) .dashing-icon:before,.file-custom .button--primary.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--primary:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--primary.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--primary:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--primary.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--primary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--primary:not(.button--transparent) .button--navigation:before,.file-custom .button--primary.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--primary.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--primary:not(.button--transparent) .dashing-icon:before,button.button--primary:not(.button--transparent) i.dashing-tooltip:before,button.button--primary:not(.button--transparent) i.dashing-clippy:before,button.button--primary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--primary:not(.button--transparent) .button--navigation:before,input[type='submit'].button--primary:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--primary:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--primary:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--primary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--primary:not(.button--transparent) .button--navigation:before,input[type='reset'].button--primary:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--primary:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--primary:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--primary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--primary:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--gray,.file-custom .button--gray.file-custom--button,.button.button--grey,.file-custom .button--grey.file-custom--button,.button.button--secondary,.file-custom .button--secondary.file-custom--button,button.button--gray,button.button--grey,button.button--secondary,input[type='submit'].button--gray,input[type='submit'].button--grey,input[type='submit'].button--secondary,input[type='reset'].button--gray,input[type='reset'].button--grey,input[type='reset'].button--secondary{background-color:#D4D4D4;color:#222}.button.button--gray:hover,.file-custom .button--gray.file-custom--button:hover,.button.button--gray:focus,.file-custom .button--gray.file-custom--button:focus,.button.button--grey:hover,.file-custom .button--grey.file-custom--button:hover,.button.button--grey:focus,.file-custom .button--grey.file-custom--button:focus,.button.button--secondary:hover,.file-custom .button--secondary.file-custom--button:hover,.button.button--secondary:focus,.file-custom .button--secondary.file-custom--button:focus,button.button--gray:hover,button.button--gray:focus,button.button--grey:hover,button.button--grey:focus,button.button--secondary:hover,button.button--secondary:focus,input[type='submit'].button--gray:hover,input[type='submit'].button--gray:focus,input[type='submit'].button--grey:hover,input[type='submit'].button--grey:focus,input[type='submit'].button--secondary:hover,input[type='submit'].button--secondary:focus,input[type='reset'].button--gray:hover,input[type='reset'].button--gray:focus,input[type='reset'].button--grey:hover,input[type='reset'].button--grey:focus,input[type='reset'].button--secondary:hover,input[type='reset'].button--secondary:focus{background-color:#bbb;color:#222}.button.button--gray:active,.file-custom .button--gray.file-custom--button:active,.button.button--grey:active,.file-custom .button--grey.file-custom--button:active,.button.button--secondary:active,.file-custom .button--secondary.file-custom--button:active,button.button--gray:active,button.button--grey:active,button.button--secondary:active,input[type='submit'].button--gray:active,input[type='submit'].button--grey:active,input[type='submit'].button--secondary:active,input[type='reset'].button--gray:active,input[type='reset'].button--grey:active,input[type='reset'].button--secondary:active{background-color:#aeaeae}.button.button--gray:not(.button--transparent) .dashing-icon:before,.file-custom .button--gray.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--gray:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--gray.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--gray:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--gray.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--gray:not(.button--transparent) .button--navigation:before,.file-custom .button--gray.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--gray.file-custom--button:not(.button--transparent) .button--navigation:before,.button.button--grey:not(.button--transparent) .dashing-icon:before,.file-custom .button--grey.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--grey:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--grey.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--grey:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--grey.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--grey:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--grey:not(.button--transparent) .button--navigation:before,.file-custom .button--grey.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--grey.file-custom--button:not(.button--transparent) .button--navigation:before,.button.button--secondary:not(.button--transparent) .dashing-icon:before,.file-custom .button--secondary.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--secondary:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--secondary.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--secondary:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--secondary.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--secondary:not(.button--transparent) .button--navigation:before,.file-custom .button--secondary.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--secondary.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--gray:not(.button--transparent) .dashing-icon:before,button.button--gray:not(.button--transparent) i.dashing-tooltip:before,button.button--gray:not(.button--transparent) i.dashing-clippy:before,button.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--gray:not(.button--transparent) .button--navigation:before,button.button--grey:not(.button--transparent) .dashing-icon:before,button.button--grey:not(.button--transparent) i.dashing-tooltip:before,button.button--grey:not(.button--transparent) i.dashing-clippy:before,button.button--grey:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--grey:not(.button--transparent) .button--navigation:before,button.button--secondary:not(.button--transparent) .dashing-icon:before,button.button--secondary:not(.button--transparent) i.dashing-tooltip:before,button.button--secondary:not(.button--transparent) i.dashing-clippy:before,button.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--secondary:not(.button--transparent) .button--navigation:before,input[type='submit'].button--gray:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--gray:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--gray:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--gray:not(.button--transparent) .button--navigation:before,input[type='submit'].button--grey:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--grey:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--grey:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--grey:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--grey:not(.button--transparent) .button--navigation:before,input[type='submit'].button--secondary:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--secondary:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--secondary:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--secondary:not(.button--transparent) .button--navigation:before,input[type='reset'].button--gray:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--gray:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--gray:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--gray:not(.button--transparent) .button--navigation:before,input[type='reset'].button--grey:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--grey:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--grey:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--grey:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--grey:not(.button--transparent) .button--navigation:before,input[type='reset'].button--secondary:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--secondary:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--secondary:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--secondary:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--gray .dashing-icon:before,.file-custom .button--gray.file-custom--button .dashing-icon:before,.button.button--gray i.dashing-tooltip:before,.file-custom .button--gray.file-custom--button i.dashing-tooltip:before,.button.button--gray i.dashing-clippy:before,.file-custom .button--gray.file-custom--button i.dashing-clippy:before,.button.button--gray .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--gray .button--navigation:before,.file-custom .button--gray.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--gray.file-custom--button .button--navigation:before,.button.button--grey .dashing-icon:before,.file-custom .button--grey.file-custom--button .dashing-icon:before,.button.button--grey i.dashing-tooltip:before,.file-custom .button--grey.file-custom--button i.dashing-tooltip:before,.button.button--grey i.dashing-clippy:before,.file-custom .button--grey.file-custom--button i.dashing-clippy:before,.button.button--grey .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--grey .button--navigation:before,.file-custom .button--grey.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--grey.file-custom--button .button--navigation:before,.button.button--secondary .dashing-icon:before,.file-custom .button--secondary.file-custom--button .dashing-icon:before,.button.button--secondary i.dashing-tooltip:before,.file-custom .button--secondary.file-custom--button i.dashing-tooltip:before,.button.button--secondary i.dashing-clippy:before,.file-custom .button--secondary.file-custom--button i.dashing-clippy:before,.button.button--secondary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--secondary .button--navigation:before,.file-custom .button--secondary.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--secondary.file-custom--button .button--navigation:before,button.button--gray .dashing-icon:before,button.button--gray i.dashing-tooltip:before,button.button--gray i.dashing-clippy:before,button.button--gray .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--gray .button--navigation:before,button.button--grey .dashing-icon:before,button.button--grey i.dashing-tooltip:before,button.button--grey i.dashing-clippy:before,button.button--grey .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--grey .button--navigation:before,button.button--secondary .dashing-icon:before,button.button--secondary i.dashing-tooltip:before,button.button--secondary i.dashing-clippy:before,button.button--secondary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--secondary .button--navigation:before,input[type='submit'].button--gray .dashing-icon:before,input[type='submit'].button--gray i.dashing-tooltip:before,input[type='submit'].button--gray i.dashing-clippy:before,input[type='submit'].button--gray .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--gray .button--navigation:before,input[type='submit'].button--grey .dashing-icon:before,input[type='submit'].button--grey i.dashing-tooltip:before,input[type='submit'].button--grey i.dashing-clippy:before,input[type='submit'].button--grey .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--grey .button--navigation:before,input[type='submit'].button--secondary .dashing-icon:before,input[type='submit'].button--secondary i.dashing-tooltip:before,input[type='submit'].button--secondary i.dashing-clippy:before,input[type='submit'].button--secondary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--secondary .button--navigation:before,input[type='reset'].button--gray .dashing-icon:before,input[type='reset'].button--gray i.dashing-tooltip:before,input[type='reset'].button--gray i.dashing-clippy:before,input[type='reset'].button--gray .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--gray .button--navigation:before,input[type='reset'].button--grey .dashing-icon:before,input[type='reset'].button--grey i.dashing-tooltip:before,input[type='reset'].button--grey i.dashing-clippy:before,input[type='reset'].button--grey .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--grey .button--navigation:before,input[type='reset'].button--secondary .dashing-icon:before,input[type='reset'].button--secondary i.dashing-tooltip:before,input[type='reset'].button--secondary i.dashing-clippy:before,input[type='reset'].button--secondary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--secondary .button--navigation:before{color:#555 !important}.button.button--blue,.file-custom .button--blue.file-custom--button,button.button--blue,input[type='submit'].button--blue,input[type='reset'].button--blue{background-color:#3F70C9;color:#fff}.button.button--blue:hover,.file-custom .button--blue.file-custom--button:hover,.button.button--blue:focus,.file-custom .button--blue.file-custom--button:focus,button.button--blue:hover,button.button--blue:focus,input[type='submit'].button--blue:hover,input[type='submit'].button--blue:focus,input[type='reset'].button--blue:hover,input[type='reset'].button--blue:focus{background-color:#2f59a6;color:#fff}.button.button--blue:active,.file-custom .button--blue.file-custom--button:active,button.button--blue:active,input[type='submit'].button--blue:active,input[type='reset'].button--blue:active{background-color:#294f92}.button.button--blue:not(.button--transparent) .dashing-icon:before,.file-custom .button--blue.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--blue:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--blue.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--blue:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--blue.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--blue:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--blue:not(.button--transparent) .button--navigation:before,.file-custom .button--blue.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--blue.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--blue:not(.button--transparent) .dashing-icon:before,button.button--blue:not(.button--transparent) i.dashing-tooltip:before,button.button--blue:not(.button--transparent) i.dashing-clippy:before,button.button--blue:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--blue:not(.button--transparent) .button--navigation:before,input[type='submit'].button--blue:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--blue:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--blue:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--blue:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--blue:not(.button--transparent) .button--navigation:before,input[type='reset'].button--blue:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--blue:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--blue:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--blue:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--blue:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--green,.file-custom .button--green.file-custom--button,button.button--green,input[type='submit'].button--green,input[type='reset'].button--green{background-color:#09AA66;color:#fff}.button.button--green:hover,.file-custom .button--green.file-custom--button:hover,.button.button--green:focus,.file-custom .button--green.file-custom--button:focus,button.button--green:hover,button.button--green:focus,input[type='submit'].button--green:hover,input[type='submit'].button--green:focus,input[type='reset'].button--green:hover,input[type='reset'].button--green:focus{background-color:#067a49;color:#fff}.button.button--green:active,.file-custom .button--green.file-custom--button:active,button.button--green:active,input[type='submit'].button--green:active,input[type='reset'].button--green:active{background-color:#05613a}.button.button--green:not(.button--transparent) .dashing-icon:before,.file-custom .button--green.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--green:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--green.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--green:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--green.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--green:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--green:not(.button--transparent) .button--navigation:before,.file-custom .button--green.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--green.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--green:not(.button--transparent) .dashing-icon:before,button.button--green:not(.button--transparent) i.dashing-tooltip:before,button.button--green:not(.button--transparent) i.dashing-clippy:before,button.button--green:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--green:not(.button--transparent) .button--navigation:before,input[type='submit'].button--green:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--green:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--green:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--green:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--green:not(.button--transparent) .button--navigation:before,input[type='reset'].button--green:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--green:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--green:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--green:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--green:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--orange,.file-custom .button--orange.file-custom--button,button.button--orange,input[type='submit'].button--orange,input[type='reset'].button--orange{background-color:#FFA11F;color:#000}.button.button--orange:hover,.file-custom .button--orange.file-custom--button:hover,.button.button--orange:focus,.file-custom .button--orange.file-custom--button:focus,button.button--orange:hover,button.button--orange:focus,input[type='submit'].button--orange:hover,input[type='submit'].button--orange:focus,input[type='reset'].button--orange:hover,input[type='reset'].button--orange:focus{background-color:#eb8800;color:#000}.button.button--orange:active,.file-custom .button--orange.file-custom--button:active,button.button--orange:active,input[type='submit'].button--orange:active,input[type='reset'].button--orange:active{background-color:#d27a00}.button.button--orange:not(.button--transparent) .dashing-icon:before,.file-custom .button--orange.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--orange:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--orange.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--orange:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--orange.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--orange:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--orange:not(.button--transparent) .button--navigation:before,.file-custom .button--orange.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--orange.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--orange:not(.button--transparent) .dashing-icon:before,button.button--orange:not(.button--transparent) i.dashing-tooltip:before,button.button--orange:not(.button--transparent) i.dashing-clippy:before,button.button--orange:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--orange:not(.button--transparent) .button--navigation:before,input[type='submit'].button--orange:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--orange:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--orange:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--orange:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--orange:not(.button--transparent) .button--navigation:before,input[type='reset'].button--orange:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--orange:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--orange:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--orange:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--orange:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--purple,.file-custom .button--purple.file-custom--button,button.button--purple,input[type='submit'].button--purple,input[type='reset'].button--purple{background-color:#9F65AE;color:#fff}.button.button--purple:hover,.file-custom .button--purple.file-custom--button:hover,.button.button--purple:focus,.file-custom .button--purple.file-custom--button:focus,button.button--purple:hover,button.button--purple:focus,input[type='submit'].button--purple:hover,input[type='submit'].button--purple:focus,input[type='reset'].button--purple:hover,input[type='reset'].button--purple:focus{background-color:#844d93;color:#fff}.button.button--purple:active,.file-custom .button--purple.file-custom--button:active,button.button--purple:active,input[type='submit'].button--purple:active,input[type='reset'].button--purple:active{background-color:#754482}.button.button--purple:not(.button--transparent) .dashing-icon:before,.file-custom .button--purple.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--purple:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--purple.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--purple:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--purple.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--purple:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--purple:not(.button--transparent) .button--navigation:before,.file-custom .button--purple.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--purple.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--purple:not(.button--transparent) .dashing-icon:before,button.button--purple:not(.button--transparent) i.dashing-tooltip:before,button.button--purple:not(.button--transparent) i.dashing-clippy:before,button.button--purple:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--purple:not(.button--transparent) .button--navigation:before,input[type='submit'].button--purple:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--purple:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--purple:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--purple:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--purple:not(.button--transparent) .button--navigation:before,input[type='reset'].button--purple:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--purple:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--purple:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--purple:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--purple:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--red,.file-custom .button--red.file-custom--button,button.button--red,input[type='submit'].button--red,input[type='reset'].button--red{background-color:#DA3D30;color:#fff}.button.button--red:hover,.file-custom .button--red.file-custom--button:hover,.button.button--red:focus,.file-custom .button--red.file-custom--button:focus,button.button--red:hover,button.button--red:focus,input[type='submit'].button--red:hover,input[type='submit'].button--red:focus,input[type='reset'].button--red:hover,input[type='reset'].button--red:focus{background-color:#b62c21;color:#fff}.button.button--red:active,.file-custom .button--red.file-custom--button:active,button.button--red:active,input[type='submit'].button--red:active,input[type='reset'].button--red:active{background-color:#a1271d}.button.button--red:not(.button--transparent) .dashing-icon:before,.file-custom .button--red.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--red:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--red.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--red:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--red.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--red:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--red:not(.button--transparent) .button--navigation:before,.file-custom .button--red.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--red.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--red:not(.button--transparent) .dashing-icon:before,button.button--red:not(.button--transparent) i.dashing-tooltip:before,button.button--red:not(.button--transparent) i.dashing-clippy:before,button.button--red:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--red:not(.button--transparent) .button--navigation:before,input[type='submit'].button--red:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--red:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--red:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--red:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--red:not(.button--transparent) .button--navigation:before,input[type='reset'].button--red:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--red:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--red:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--red:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--red:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--white,.file-custom .button--white.file-custom--button,button.button--white,input[type='submit'].button--white,input[type='reset'].button--white{background-color:#fff;color:#3B3B3B}.button.button--white:hover,.file-custom .button--white.file-custom--button:hover,.button.button--white:focus,.file-custom .button--white.file-custom--button:focus,button.button--white:hover,button.button--white:focus,input[type='submit'].button--white:hover,input[type='submit'].button--white:focus,input[type='reset'].button--white:hover,input[type='reset'].button--white:focus{background-color:#e6e6e6;color:#3B3B3B}.button.button--white:active,.file-custom .button--white.file-custom--button:active,button.button--white:active,input[type='submit'].button--white:active,input[type='reset'].button--white:active{background-color:#d9d9d9}.button.button--white:not(.button--transparent) .dashing-icon:before,.file-custom .button--white.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--white:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--white.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--white:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--white.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--white:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--white:not(.button--transparent) .button--navigation:before,.file-custom .button--white.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--white.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--white:not(.button--transparent) .dashing-icon:before,button.button--white:not(.button--transparent) i.dashing-tooltip:before,button.button--white:not(.button--transparent) i.dashing-clippy:before,button.button--white:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--white:not(.button--transparent) .button--navigation:before,input[type='submit'].button--white:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--white:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--white:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--white:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--white:not(.button--transparent) .button--navigation:before,input[type='reset'].button--white:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--white:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--white:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--white:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--white:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--black,.file-custom .button--black.file-custom--button,button.button--black,input[type='submit'].button--black,input[type='reset'].button--black{background-color:#000;color:#fff}.button.button--black:hover,.file-custom .button--black.file-custom--button:hover,.button.button--black:focus,.file-custom .button--black.file-custom--button:focus,button.button--black:hover,button.button--black:focus,input[type='submit'].button--black:hover,input[type='submit'].button--black:focus,input[type='reset'].button--black:hover,input[type='reset'].button--black:focus{background-color:#000;color:#fff}.button.button--black:active,.file-custom .button--black.file-custom--button:active,button.button--black:active,input[type='submit'].button--black:active,input[type='reset'].button--black:active{background-color:#000}.button.button--black:not(.button--transparent) .dashing-icon:before,.file-custom .button--black.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--black:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--black.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--black:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--black.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--black:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--black:not(.button--transparent) .button--navigation:before,.file-custom .button--black.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--black.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--black:not(.button--transparent) .dashing-icon:before,button.button--black:not(.button--transparent) i.dashing-tooltip:before,button.button--black:not(.button--transparent) i.dashing-clippy:before,button.button--black:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--black:not(.button--transparent) .button--navigation:before,input[type='submit'].button--black:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--black:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--black:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--black:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--black:not(.button--transparent) .button--navigation:before,input[type='reset'].button--black:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--black:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--black:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--black:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--black:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--transparent,.file-custom .button--transparent.file-custom--button,button.button--transparent,input[type='submit'].button--transparent,input[type='reset'].button--transparent{background-color:rgba(255,255,255,0);color:#3F70C9;background-color:rgba(255,255,255,0);color:#3F70C9}.button.button--transparent:hover,.file-custom .button--transparent.file-custom--button:hover,.button.button--transparent:focus,.file-custom .button--transparent.file-custom--button:focus,button.button--transparent:hover,button.button--transparent:focus,input[type='submit'].button--transparent:hover,input[type='submit'].button--transparent:focus,input[type='reset'].button--transparent:hover,input[type='reset'].button--transparent:focus{background-color:rgba(230,230,230,0);color:#3F70C9}.button.button--transparent:active,.file-custom .button--transparent.file-custom--button:active,button.button--transparent:active,input[type='submit'].button--transparent:active,input[type='reset'].button--transparent:active{background-color:rgba(217,217,217,0)}.button.button--transparent:not(.button--transparent) .dashing-icon:before,.file-custom .button--transparent.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--transparent:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--transparent.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--transparent:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--transparent.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent:not(.button--transparent) .button--navigation:before,.file-custom .button--transparent.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--transparent:not(.button--transparent) .dashing-icon:before,button.button--transparent:not(.button--transparent) i.dashing-tooltip:before,button.button--transparent:not(.button--transparent) i.dashing-clippy:before,button.button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent:not(.button--transparent) .button--navigation:before,input[type='submit'].button--transparent:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--transparent:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--transparent:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent:not(.button--transparent) .button--navigation:before,input[type='reset'].button--transparent:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--transparent:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--transparent:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--transparent:hover,.file-custom .button--transparent.file-custom--button:hover,.button.button--transparent:focus,.file-custom .button--transparent.file-custom--button:focus,button.button--transparent:hover,button.button--transparent:focus,input[type='submit'].button--transparent:hover,input[type='submit'].button--transparent:focus,input[type='reset'].button--transparent:hover,input[type='reset'].button--transparent:focus{opacity:.6}.button.button--transparent:active,.file-custom .button--transparent.file-custom--button:active,button.button--transparent:active,input[type='submit'].button--transparent:active,input[type='reset'].button--transparent:active{opacity:.9}.button.button--transparent:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent:not(.button--icon) .dashing-icon:before,button.button--transparent:not(.button--icon) i.dashing-tooltip:before,button.button--transparent:not(.button--icon) i.dashing-clippy:before,button.button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent:not(.button--icon) .button--navigation:before{color:#3F70C9}.button.button--transparent:not(.button--icon),.file-custom .button--transparent.file-custom--button:not(.button--icon),button.button--transparent:not(.button--icon),input[type='submit'].button--transparent:not(.button--icon),input[type='reset'].button--transparent:not(.button--icon){padding-left:0;padding-right:0}.button.button--transparent.button--primary,.file-custom .button--transparent.button--primary.file-custom--button,button.button--transparent.button--primary,input[type='submit'].button--transparent.button--primary,input[type='reset'].button--transparent.button--primary{background-color:rgba(255,255,255,0);color:#3F70C9}.button.button--transparent.button--primary:hover,.file-custom .button--transparent.button--primary.file-custom--button:hover,.button.button--transparent.button--primary:focus,.file-custom .button--transparent.button--primary.file-custom--button:focus,button.button--transparent.button--primary:hover,button.button--transparent.button--primary:focus,input[type='submit'].button--transparent.button--primary:hover,input[type='submit'].button--transparent.button--primary:focus,input[type='reset'].button--transparent.button--primary:hover,input[type='reset'].button--transparent.button--primary:focus{opacity:.6}.button.button--transparent.button--primary:active,.file-custom .button--transparent.button--primary.file-custom--button:active,button.button--transparent.button--primary:active,input[type='submit'].button--transparent.button--primary:active,input[type='reset'].button--transparent.button--primary:active{opacity:.9}.button.button--transparent.button--primary:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--primary:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent.button--primary:not(.button--icon) .dashing-icon:before,button.button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--primary:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--primary:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--primary:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--primary:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--primary:not(.button--icon) .button--navigation:before{color:#3F70C9}.button.button--transparent.button--secondary,.file-custom .button--transparent.button--secondary.file-custom--button,button.button--transparent.button--secondary,input[type='submit'].button--transparent.button--secondary,input[type='reset'].button--transparent.button--secondary{background-color:rgba(255,255,255,0);color:#6E6E6E}.button.button--transparent.button--secondary:hover,.file-custom .button--transparent.button--secondary.file-custom--button:hover,.button.button--transparent.button--secondary:focus,.file-custom .button--transparent.button--secondary.file-custom--button:focus,button.button--transparent.button--secondary:hover,button.button--transparent.button--secondary:focus,input[type='submit'].button--transparent.button--secondary:hover,input[type='submit'].button--transparent.button--secondary:focus,input[type='reset'].button--transparent.button--secondary:hover,input[type='reset'].button--transparent.button--secondary:focus{opacity:.6}.button.button--transparent.button--secondary:active,.file-custom .button--transparent.button--secondary.file-custom--button:active,button.button--transparent.button--secondary:active,input[type='submit'].button--transparent.button--secondary:active,input[type='reset'].button--transparent.button--secondary:active{opacity:.9}.button.button--transparent.button--secondary:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--secondary:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent.button--secondary:not(.button--icon) .dashing-icon:before,button.button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--secondary:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--secondary:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--secondary:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--secondary:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--secondary:not(.button--icon) .button--navigation:before{color:#6E6E6E}.button.button--transparent.button--blue,.file-custom .button--transparent.button--blue.file-custom--button,button.button--transparent.button--blue,input[type='submit'].button--transparent.button--blue,input[type='reset'].button--transparent.button--blue{background-color:rgba(255,255,255,0);color:#3F70C9}.button.button--transparent.button--blue:hover,.file-custom .button--transparent.button--blue.file-custom--button:hover,.button.button--transparent.button--blue:focus,.file-custom .button--transparent.button--blue.file-custom--button:focus,button.button--transparent.button--blue:hover,button.button--transparent.button--blue:focus,input[type='submit'].button--transparent.button--blue:hover,input[type='submit'].button--transparent.button--blue:focus,input[type='reset'].button--transparent.button--blue:hover,input[type='reset'].button--transparent.button--blue:focus{opacity:.6}.button.button--transparent.button--blue:active,.file-custom .button--transparent.button--blue.file-custom--button:active,button.button--transparent.button--blue:active,input[type='submit'].button--transparent.button--blue:active,input[type='reset'].button--transparent.button--blue:active{opacity:.9}.button.button--transparent.button--blue:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--blue:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent.button--blue:not(.button--icon) .dashing-icon:before,button.button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--blue:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--blue:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--blue:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--blue:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--blue:not(.button--icon) .button--navigation:before{color:#3F70C9}.button.button--transparent.button--gray,.file-custom .button--transparent.button--gray.file-custom--button,.button.button--transparent.button--grey,.file-custom .button--transparent.button--grey.file-custom--button,button.button--transparent.button--gray,button.button--transparent.button--grey,input[type='submit'].button--transparent.button--gray,input[type='submit'].button--transparent.button--grey,input[type='reset'].button--transparent.button--gray,input[type='reset'].button--transparent.button--grey{background-color:rgba(255,255,255,0);color:#6E6E6E}.button.button--transparent.button--gray:hover,.file-custom .button--transparent.button--gray.file-custom--button:hover,.button.button--transparent.button--gray:focus,.file-custom .button--transparent.button--gray.file-custom--button:focus,.button.button--transparent.button--grey:hover,.file-custom .button--transparent.button--grey.file-custom--button:hover,.button.button--transparent.button--grey:focus,.file-custom .button--transparent.button--grey.file-custom--button:focus,button.button--transparent.button--gray:hover,button.button--transparent.button--gray:focus,button.button--transparent.button--grey:hover,button.button--transparent.button--grey:focus,input[type='submit'].button--transparent.button--gray:hover,input[type='submit'].button--transparent.button--gray:focus,input[type='submit'].button--transparent.button--grey:hover,input[type='submit'].button--transparent.button--grey:focus,input[type='reset'].button--transparent.button--gray:hover,input[type='reset'].button--transparent.button--gray:focus,input[type='reset'].button--transparent.button--grey:hover,input[type='reset'].button--transparent.button--grey:focus{opacity:.6}.button.button--transparent.button--gray:active,.file-custom .button--transparent.button--gray.file-custom--button:active,.button.button--transparent.button--grey:active,.file-custom .button--transparent.button--grey.file-custom--button:active,button.button--transparent.button--gray:active,button.button--transparent.button--grey:active,input[type='submit'].button--transparent.button--gray:active,input[type='submit'].button--transparent.button--grey:active,input[type='reset'].button--transparent.button--gray:active,input[type='reset'].button--transparent.button--grey:active{opacity:.9}.button.button--transparent.button--gray:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--gray:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--gray:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .button--navigation:before,.button.button--transparent.button--grey:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--grey:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--grey:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--grey:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--grey:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent.button--gray:not(.button--icon) .dashing-icon:before,button.button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--gray:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--gray:not(.button--icon) .button--navigation:before,button.button--transparent.button--grey:not(.button--icon) .dashing-icon:before,button.button--transparent.button--grey:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--grey:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--grey:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--grey:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--gray:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--gray:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--gray:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--grey:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--grey:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--grey:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--grey:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--grey:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--gray:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--gray:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--gray:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--grey:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--grey:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--grey:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--grey:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--grey:not(.button--icon) .button--navigation:before{color:#6E6E6E}.button.button--transparent.button--green,.file-custom .button--transparent.button--green.file-custom--button,button.button--transparent.button--green,input[type='submit'].button--transparent.button--green,input[type='reset'].button--transparent.button--green{background-color:rgba(255,255,255,0);color:#09AA66}.button.button--transparent.button--green:hover,.file-custom .button--transparent.button--green.file-custom--button:hover,.button.button--transparent.button--green:focus,.file-custom .button--transparent.button--green.file-custom--button:focus,button.button--transparent.button--green:hover,button.button--transparent.button--green:focus,input[type='submit'].button--transparent.button--green:hover,input[type='submit'].button--transparent.button--green:focus,input[type='reset'].button--transparent.button--green:hover,input[type='reset'].button--transparent.button--green:focus{opacity:.6}.button.button--transparent.button--green:active,.file-custom .button--transparent.button--green.file-custom--button:active,button.button--transparent.button--green:active,input[type='submit'].button--transparent.button--green:active,input[type='reset'].button--transparent.button--green:active{opacity:.9}.button.button--transparent.button--green:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--green:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--green:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent.button--green:not(.button--icon) .dashing-icon:before,button.button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--green:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--green:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--green:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--green:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--green:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--green:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--green:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--green:not(.button--icon) .button--navigation:before{color:#09AA66}.button.button--transparent.button--red,.file-custom .button--transparent.button--red.file-custom--button,button.button--transparent.button--red,input[type='submit'].button--transparent.button--red,input[type='reset'].button--transparent.button--red{background-color:rgba(255,255,255,0);color:#DA3D30}.button.button--transparent.button--red:hover,.file-custom .button--transparent.button--red.file-custom--button:hover,.button.button--transparent.button--red:focus,.file-custom .button--transparent.button--red.file-custom--button:focus,button.button--transparent.button--red:hover,button.button--transparent.button--red:focus,input[type='submit'].button--transparent.button--red:hover,input[type='submit'].button--transparent.button--red:focus,input[type='reset'].button--transparent.button--red:hover,input[type='reset'].button--transparent.button--red:focus{opacity:.6}.button.button--transparent.button--red:active,.file-custom .button--transparent.button--red.file-custom--button:active,button.button--transparent.button--red:active,input[type='submit'].button--transparent.button--red:active,input[type='reset'].button--transparent.button--red:active{opacity:.9}.button.button--transparent.button--red:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--red:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--red:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent.button--red:not(.button--icon) .dashing-icon:before,button.button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--red:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--red:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--red:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--red:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--red:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--red:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--red:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--red:not(.button--icon) .button--navigation:before{color:#DA3D30}.button.button--transparent.button--orange,.file-custom .button--transparent.button--orange.file-custom--button,button.button--transparent.button--orange,input[type='submit'].button--transparent.button--orange,input[type='reset'].button--transparent.button--orange{background-color:rgba(255,255,255,0);color:#FFA11F}.button.button--transparent.button--orange:hover,.file-custom .button--transparent.button--orange.file-custom--button:hover,.button.button--transparent.button--orange:focus,.file-custom .button--transparent.button--orange.file-custom--button:focus,button.button--transparent.button--orange:hover,button.button--transparent.button--orange:focus,input[type='submit'].button--transparent.button--orange:hover,input[type='submit'].button--transparent.button--orange:focus,input[type='reset'].button--transparent.button--orange:hover,input[type='reset'].button--transparent.button--orange:focus{opacity:.6}.button.button--transparent.button--orange:active,.file-custom .button--transparent.button--orange.file-custom--button:active,button.button--transparent.button--orange:active,input[type='submit'].button--transparent.button--orange:active,input[type='reset'].button--transparent.button--orange:active{opacity:.9}.button.button--transparent.button--orange:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--orange:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent.button--orange:not(.button--icon) .dashing-icon:before,button.button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--orange:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--orange:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--orange:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--orange:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--orange:not(.button--icon) .button--navigation:before{color:#FFA11F}.button.button--transparent.button--purple,.file-custom .button--transparent.button--purple.file-custom--button,button.button--transparent.button--purple,input[type='submit'].button--transparent.button--purple,input[type='reset'].button--transparent.button--purple{background-color:rgba(255,255,255,0);color:#9F65AE}.button.button--transparent.button--purple:hover,.file-custom .button--transparent.button--purple.file-custom--button:hover,.button.button--transparent.button--purple:focus,.file-custom .button--transparent.button--purple.file-custom--button:focus,button.button--transparent.button--purple:hover,button.button--transparent.button--purple:focus,input[type='submit'].button--transparent.button--purple:hover,input[type='submit'].button--transparent.button--purple:focus,input[type='reset'].button--transparent.button--purple:hover,input[type='reset'].button--transparent.button--purple:focus{opacity:.6}.button.button--transparent.button--purple:active,.file-custom .button--transparent.button--purple.file-custom--button:active,button.button--transparent.button--purple:active,input[type='submit'].button--transparent.button--purple:active,input[type='reset'].button--transparent.button--purple:active{opacity:.9}.button.button--transparent.button--purple:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--purple:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent.button--purple:not(.button--icon) .dashing-icon:before,button.button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--purple:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--purple:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--purple:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--purple:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--purple:not(.button--icon) .button--navigation:before{color:#9F65AE}.button.button--transparent.button--white,.file-custom .button--transparent.button--white.file-custom--button,button.button--transparent.button--white,input[type='submit'].button--transparent.button--white,input[type='reset'].button--transparent.button--white{background-color:rgba(255,255,255,0);color:#fff}.button.button--transparent.button--white:hover,.file-custom .button--transparent.button--white.file-custom--button:hover,.button.button--transparent.button--white:focus,.file-custom .button--transparent.button--white.file-custom--button:focus,button.button--transparent.button--white:hover,button.button--transparent.button--white:focus,input[type='submit'].button--transparent.button--white:hover,input[type='submit'].button--transparent.button--white:focus,input[type='reset'].button--transparent.button--white:hover,input[type='reset'].button--transparent.button--white:focus{opacity:.6}.button.button--transparent.button--white:active,.file-custom .button--transparent.button--white.file-custom--button:active,button.button--transparent.button--white:active,input[type='submit'].button--transparent.button--white:active,input[type='reset'].button--transparent.button--white:active{opacity:.9}.button.button--transparent.button--white:not(.button--icon) .dashing-icon:before,.file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .dashing-icon:before,.button.button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before,.file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) i.dashing-tooltip:before,.button.button--transparent.button--white:not(.button--icon) i.dashing-clippy:before,.file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) i.dashing-clippy:before,.button.button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--transparent.button--white:not(.button--icon) .button--navigation:before,.file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .button--navigation:before,button.button--transparent.button--white:not(.button--icon) .dashing-icon:before,button.button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before,button.button--transparent.button--white:not(.button--icon) i.dashing-clippy:before,button.button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--transparent.button--white:not(.button--icon) .button--navigation:before,input[type='submit'].button--transparent.button--white:not(.button--icon) .dashing-icon:before,input[type='submit'].button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before,input[type='submit'].button--transparent.button--white:not(.button--icon) i.dashing-clippy:before,input[type='submit'].button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--transparent.button--white:not(.button--icon) .button--navigation:before,input[type='reset'].button--transparent.button--white:not(.button--icon) .dashing-icon:before,input[type='reset'].button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before,input[type='reset'].button--transparent.button--white:not(.button--icon) i.dashing-clippy:before,input[type='reset'].button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--transparent.button--white:not(.button--icon) .button--navigation:before{color:#fff}.button.button--border,.file-custom .button--border.file-custom--button,button.button--border,input[type='submit'].button--border,input[type='reset'].button--border{background-color:rgba(255,255,255,0);border-color:#3F70C9;color:#3F70C9;border:2px solid}.button.button--border .dashing-icon:before,.file-custom .button--border.file-custom--button .dashing-icon:before,.button.button--border i.dashing-tooltip:before,.file-custom .button--border.file-custom--button i.dashing-tooltip:before,.button.button--border i.dashing-clippy:before,.file-custom .button--border.file-custom--button i.dashing-clippy:before,.button.button--border .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border .button--navigation:before,.file-custom .button--border.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.file-custom--button .button--navigation:before,button.button--border .dashing-icon:before,button.button--border i.dashing-tooltip:before,button.button--border i.dashing-clippy:before,button.button--border .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border .button--navigation:before,input[type='submit'].button--border .dashing-icon:before,input[type='submit'].button--border i.dashing-tooltip:before,input[type='submit'].button--border i.dashing-clippy:before,input[type='submit'].button--border .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border .button--navigation:before,input[type='reset'].button--border .dashing-icon:before,input[type='reset'].button--border i.dashing-tooltip:before,input[type='reset'].button--border i.dashing-clippy:before,input[type='reset'].button--border .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border .button--navigation:before{color:#3F70C9}.button.button--border:hover,.file-custom .button--border.file-custom--button:hover,.button.button--border:focus,.file-custom .button--border.file-custom--button:focus,button.button--border:hover,button.button--border:focus,input[type='submit'].button--border:hover,input[type='submit'].button--border:focus,input[type='reset'].button--border:hover,input[type='reset'].button--border:focus{background-color:#2f59a6;border-color:rgba(255,255,255,0);color:#fff}.button.button--border:hover .dashing-icon:before,.file-custom .button--border.file-custom--button:hover .dashing-icon:before,.button.button--border:hover i.dashing-tooltip:before,.file-custom .button--border.file-custom--button:hover i.dashing-tooltip:before,.button.button--border:hover i.dashing-clippy:before,.file-custom .button--border.file-custom--button:hover i.dashing-clippy:before,.button.button--border:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border:hover .button--navigation:before,.file-custom .button--border.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.file-custom--button:hover .button--navigation:before,.button.button--border:focus .dashing-icon:before,.file-custom .button--border.file-custom--button:focus .dashing-icon:before,.button.button--border:focus i.dashing-tooltip:before,.file-custom .button--border.file-custom--button:focus i.dashing-tooltip:before,.button.button--border:focus i.dashing-clippy:before,.file-custom .button--border.file-custom--button:focus i.dashing-clippy:before,.button.button--border:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border:focus .button--navigation:before,.file-custom .button--border.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.file-custom--button:focus .button--navigation:before,button.button--border:hover .dashing-icon:before,button.button--border:hover i.dashing-tooltip:before,button.button--border:hover i.dashing-clippy:before,button.button--border:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border:hover .button--navigation:before,button.button--border:focus .dashing-icon:before,button.button--border:focus i.dashing-tooltip:before,button.button--border:focus i.dashing-clippy:before,button.button--border:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border:focus .button--navigation:before,input[type='submit'].button--border:hover .dashing-icon:before,input[type='submit'].button--border:hover i.dashing-tooltip:before,input[type='submit'].button--border:hover i.dashing-clippy:before,input[type='submit'].button--border:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border:hover .button--navigation:before,input[type='submit'].button--border:focus .dashing-icon:before,input[type='submit'].button--border:focus i.dashing-tooltip:before,input[type='submit'].button--border:focus i.dashing-clippy:before,input[type='submit'].button--border:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border:focus .button--navigation:before,input[type='reset'].button--border:hover .dashing-icon:before,input[type='reset'].button--border:hover i.dashing-tooltip:before,input[type='reset'].button--border:hover i.dashing-clippy:before,input[type='reset'].button--border:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border:hover .button--navigation:before,input[type='reset'].button--border:focus .dashing-icon:before,input[type='reset'].button--border:focus i.dashing-tooltip:before,input[type='reset'].button--border:focus i.dashing-clippy:before,input[type='reset'].button--border:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border:focus .button--navigation:before{color:#fff;transition:all 50ms ease-in-out}.button.button--border:active,.file-custom .button--border.file-custom--button:active,button.button--border:active,input[type='submit'].button--border:active,input[type='reset'].button--border:active{background-color:#294f92}@media all and (min-width: 40em){.button.button--border,.file-custom .button--border.file-custom--button,button.button--border,input[type='submit'].button--border,input[type='reset'].button--border{padding-top:calc(0.45rem - 2px);padding-bottom:calc(0.5rem - 2px);padding-left:calc(1rem - 2px);padding-right:calc(1rem - 2px)}}.button.button--border.button--primary,.file-custom .button--border.button--primary.file-custom--button,button.button--border.button--primary,input[type='submit'].button--border.button--primary,input[type='reset'].button--border.button--primary{background-color:rgba(255,255,255,0);border-color:#3F70C9;color:#3F70C9}.button.button--border.button--primary .dashing-icon:before,.file-custom .button--border.button--primary.file-custom--button .dashing-icon:before,.button.button--border.button--primary i.dashing-tooltip:before,.file-custom .button--border.button--primary.file-custom--button i.dashing-tooltip:before,.button.button--border.button--primary i.dashing-clippy:before,.file-custom .button--border.button--primary.file-custom--button i.dashing-clippy:before,.button.button--border.button--primary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--primary .button--navigation:before,.file-custom .button--border.button--primary.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--primary.file-custom--button .button--navigation:before,button.button--border.button--primary .dashing-icon:before,button.button--border.button--primary i.dashing-tooltip:before,button.button--border.button--primary i.dashing-clippy:before,button.button--border.button--primary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--primary .button--navigation:before,input[type='submit'].button--border.button--primary .dashing-icon:before,input[type='submit'].button--border.button--primary i.dashing-tooltip:before,input[type='submit'].button--border.button--primary i.dashing-clippy:before,input[type='submit'].button--border.button--primary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--primary .button--navigation:before,input[type='reset'].button--border.button--primary .dashing-icon:before,input[type='reset'].button--border.button--primary i.dashing-tooltip:before,input[type='reset'].button--border.button--primary i.dashing-clippy:before,input[type='reset'].button--border.button--primary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--primary .button--navigation:before{color:#3F70C9}.button.button--border.button--primary:hover,.file-custom .button--border.button--primary.file-custom--button:hover,.button.button--border.button--primary:focus,.file-custom .button--border.button--primary.file-custom--button:focus,button.button--border.button--primary:hover,button.button--border.button--primary:focus,input[type='submit'].button--border.button--primary:hover,input[type='submit'].button--border.button--primary:focus,input[type='reset'].button--border.button--primary:hover,input[type='reset'].button--border.button--primary:focus{background-color:#2f59a6;border-color:rgba(255,255,255,0);color:#fff}.button.button--border.button--primary:hover .dashing-icon:before,.file-custom .button--border.button--primary.file-custom--button:hover .dashing-icon:before,.button.button--border.button--primary:hover i.dashing-tooltip:before,.file-custom .button--border.button--primary.file-custom--button:hover i.dashing-tooltip:before,.button.button--border.button--primary:hover i.dashing-clippy:before,.file-custom .button--border.button--primary.file-custom--button:hover i.dashing-clippy:before,.button.button--border.button--primary:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--primary:hover .button--navigation:before,.file-custom .button--border.button--primary.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--primary.file-custom--button:hover .button--navigation:before,.button.button--border.button--primary:focus .dashing-icon:before,.file-custom .button--border.button--primary.file-custom--button:focus .dashing-icon:before,.button.button--border.button--primary:focus i.dashing-tooltip:before,.file-custom .button--border.button--primary.file-custom--button:focus i.dashing-tooltip:before,.button.button--border.button--primary:focus i.dashing-clippy:before,.file-custom .button--border.button--primary.file-custom--button:focus i.dashing-clippy:before,.button.button--border.button--primary:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--primary:focus .button--navigation:before,.file-custom .button--border.button--primary.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--primary.file-custom--button:focus .button--navigation:before,button.button--border.button--primary:hover .dashing-icon:before,button.button--border.button--primary:hover i.dashing-tooltip:before,button.button--border.button--primary:hover i.dashing-clippy:before,button.button--border.button--primary:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--primary:hover .button--navigation:before,button.button--border.button--primary:focus .dashing-icon:before,button.button--border.button--primary:focus i.dashing-tooltip:before,button.button--border.button--primary:focus i.dashing-clippy:before,button.button--border.button--primary:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--primary:focus .button--navigation:before,input[type='submit'].button--border.button--primary:hover .dashing-icon:before,input[type='submit'].button--border.button--primary:hover i.dashing-tooltip:before,input[type='submit'].button--border.button--primary:hover i.dashing-clippy:before,input[type='submit'].button--border.button--primary:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--primary:hover .button--navigation:before,input[type='submit'].button--border.button--primary:focus .dashing-icon:before,input[type='submit'].button--border.button--primary:focus i.dashing-tooltip:before,input[type='submit'].button--border.button--primary:focus i.dashing-clippy:before,input[type='submit'].button--border.button--primary:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--primary:focus .button--navigation:before,input[type='reset'].button--border.button--primary:hover .dashing-icon:before,input[type='reset'].button--border.button--primary:hover i.dashing-tooltip:before,input[type='reset'].button--border.button--primary:hover i.dashing-clippy:before,input[type='reset'].button--border.button--primary:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--primary:hover .button--navigation:before,input[type='reset'].button--border.button--primary:focus .dashing-icon:before,input[type='reset'].button--border.button--primary:focus i.dashing-tooltip:before,input[type='reset'].button--border.button--primary:focus i.dashing-clippy:before,input[type='reset'].button--border.button--primary:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--primary:focus .button--navigation:before{color:#fff;transition:all 50ms ease-in-out}.button.button--border.button--primary:active,.file-custom .button--border.button--primary.file-custom--button:active,button.button--border.button--primary:active,input[type='submit'].button--border.button--primary:active,input[type='reset'].button--border.button--primary:active{background-color:#294f92}.button.button--border.button--blue,.file-custom .button--border.button--blue.file-custom--button,button.button--border.button--blue,input[type='submit'].button--border.button--blue,input[type='reset'].button--border.button--blue{background-color:rgba(255,255,255,0);border-color:#3F70C9;color:#3F70C9}.button.button--border.button--blue .dashing-icon:before,.file-custom .button--border.button--blue.file-custom--button .dashing-icon:before,.button.button--border.button--blue i.dashing-tooltip:before,.file-custom .button--border.button--blue.file-custom--button i.dashing-tooltip:before,.button.button--border.button--blue i.dashing-clippy:before,.file-custom .button--border.button--blue.file-custom--button i.dashing-clippy:before,.button.button--border.button--blue .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--blue .button--navigation:before,.file-custom .button--border.button--blue.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--blue.file-custom--button .button--navigation:before,button.button--border.button--blue .dashing-icon:before,button.button--border.button--blue i.dashing-tooltip:before,button.button--border.button--blue i.dashing-clippy:before,button.button--border.button--blue .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--blue .button--navigation:before,input[type='submit'].button--border.button--blue .dashing-icon:before,input[type='submit'].button--border.button--blue i.dashing-tooltip:before,input[type='submit'].button--border.button--blue i.dashing-clippy:before,input[type='submit'].button--border.button--blue .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--blue .button--navigation:before,input[type='reset'].button--border.button--blue .dashing-icon:before,input[type='reset'].button--border.button--blue i.dashing-tooltip:before,input[type='reset'].button--border.button--blue i.dashing-clippy:before,input[type='reset'].button--border.button--blue .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--blue .button--navigation:before{color:#3F70C9}.button.button--border.button--blue:hover,.file-custom .button--border.button--blue.file-custom--button:hover,.button.button--border.button--blue:focus,.file-custom .button--border.button--blue.file-custom--button:focus,button.button--border.button--blue:hover,button.button--border.button--blue:focus,input[type='submit'].button--border.button--blue:hover,input[type='submit'].button--border.button--blue:focus,input[type='reset'].button--border.button--blue:hover,input[type='reset'].button--border.button--blue:focus{background-color:#2f59a6;border-color:rgba(255,255,255,0);color:#fff}.button.button--border.button--blue:hover .dashing-icon:before,.file-custom .button--border.button--blue.file-custom--button:hover .dashing-icon:before,.button.button--border.button--blue:hover i.dashing-tooltip:before,.file-custom .button--border.button--blue.file-custom--button:hover i.dashing-tooltip:before,.button.button--border.button--blue:hover i.dashing-clippy:before,.file-custom .button--border.button--blue.file-custom--button:hover i.dashing-clippy:before,.button.button--border.button--blue:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--blue:hover .button--navigation:before,.file-custom .button--border.button--blue.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--blue.file-custom--button:hover .button--navigation:before,.button.button--border.button--blue:focus .dashing-icon:before,.file-custom .button--border.button--blue.file-custom--button:focus .dashing-icon:before,.button.button--border.button--blue:focus i.dashing-tooltip:before,.file-custom .button--border.button--blue.file-custom--button:focus i.dashing-tooltip:before,.button.button--border.button--blue:focus i.dashing-clippy:before,.file-custom .button--border.button--blue.file-custom--button:focus i.dashing-clippy:before,.button.button--border.button--blue:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--blue:focus .button--navigation:before,.file-custom .button--border.button--blue.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--blue.file-custom--button:focus .button--navigation:before,button.button--border.button--blue:hover .dashing-icon:before,button.button--border.button--blue:hover i.dashing-tooltip:before,button.button--border.button--blue:hover i.dashing-clippy:before,button.button--border.button--blue:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--blue:hover .button--navigation:before,button.button--border.button--blue:focus .dashing-icon:before,button.button--border.button--blue:focus i.dashing-tooltip:before,button.button--border.button--blue:focus i.dashing-clippy:before,button.button--border.button--blue:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--blue:focus .button--navigation:before,input[type='submit'].button--border.button--blue:hover .dashing-icon:before,input[type='submit'].button--border.button--blue:hover i.dashing-tooltip:before,input[type='submit'].button--border.button--blue:hover i.dashing-clippy:before,input[type='submit'].button--border.button--blue:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--blue:hover .button--navigation:before,input[type='submit'].button--border.button--blue:focus .dashing-icon:before,input[type='submit'].button--border.button--blue:focus i.dashing-tooltip:before,input[type='submit'].button--border.button--blue:focus i.dashing-clippy:before,input[type='submit'].button--border.button--blue:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--blue:focus .button--navigation:before,input[type='reset'].button--border.button--blue:hover .dashing-icon:before,input[type='reset'].button--border.button--blue:hover i.dashing-tooltip:before,input[type='reset'].button--border.button--blue:hover i.dashing-clippy:before,input[type='reset'].button--border.button--blue:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--blue:hover .button--navigation:before,input[type='reset'].button--border.button--blue:focus .dashing-icon:before,input[type='reset'].button--border.button--blue:focus i.dashing-tooltip:before,input[type='reset'].button--border.button--blue:focus i.dashing-clippy:before,input[type='reset'].button--border.button--blue:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--blue:focus .button--navigation:before{color:#fff;transition:all 50ms ease-in-out}.button.button--border.button--blue:active,.file-custom .button--border.button--blue.file-custom--button:active,button.button--border.button--blue:active,input[type='submit'].button--border.button--blue:active,input[type='reset'].button--border.button--blue:active{background-color:#294f92}.button.button--border.button--green,.file-custom .button--border.button--green.file-custom--button,button.button--border.button--green,input[type='submit'].button--border.button--green,input[type='reset'].button--border.button--green{background-color:rgba(255,255,255,0);border-color:#09AA66;color:#09AA66}.button.button--border.button--green .dashing-icon:before,.file-custom .button--border.button--green.file-custom--button .dashing-icon:before,.button.button--border.button--green i.dashing-tooltip:before,.file-custom .button--border.button--green.file-custom--button i.dashing-tooltip:before,.button.button--border.button--green i.dashing-clippy:before,.file-custom .button--border.button--green.file-custom--button i.dashing-clippy:before,.button.button--border.button--green .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--green .button--navigation:before,.file-custom .button--border.button--green.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--green.file-custom--button .button--navigation:before,button.button--border.button--green .dashing-icon:before,button.button--border.button--green i.dashing-tooltip:before,button.button--border.button--green i.dashing-clippy:before,button.button--border.button--green .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--green .button--navigation:before,input[type='submit'].button--border.button--green .dashing-icon:before,input[type='submit'].button--border.button--green i.dashing-tooltip:before,input[type='submit'].button--border.button--green i.dashing-clippy:before,input[type='submit'].button--border.button--green .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--green .button--navigation:before,input[type='reset'].button--border.button--green .dashing-icon:before,input[type='reset'].button--border.button--green i.dashing-tooltip:before,input[type='reset'].button--border.button--green i.dashing-clippy:before,input[type='reset'].button--border.button--green .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--green .button--navigation:before{color:#09AA66}.button.button--border.button--green:hover,.file-custom .button--border.button--green.file-custom--button:hover,.button.button--border.button--green:focus,.file-custom .button--border.button--green.file-custom--button:focus,button.button--border.button--green:hover,button.button--border.button--green:focus,input[type='submit'].button--border.button--green:hover,input[type='submit'].button--border.button--green:focus,input[type='reset'].button--border.button--green:hover,input[type='reset'].button--border.button--green:focus{background-color:#067a49;border-color:rgba(255,255,255,0);color:#fff}.button.button--border.button--green:hover .dashing-icon:before,.file-custom .button--border.button--green.file-custom--button:hover .dashing-icon:before,.button.button--border.button--green:hover i.dashing-tooltip:before,.file-custom .button--border.button--green.file-custom--button:hover i.dashing-tooltip:before,.button.button--border.button--green:hover i.dashing-clippy:before,.file-custom .button--border.button--green.file-custom--button:hover i.dashing-clippy:before,.button.button--border.button--green:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--green:hover .button--navigation:before,.file-custom .button--border.button--green.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--green.file-custom--button:hover .button--navigation:before,.button.button--border.button--green:focus .dashing-icon:before,.file-custom .button--border.button--green.file-custom--button:focus .dashing-icon:before,.button.button--border.button--green:focus i.dashing-tooltip:before,.file-custom .button--border.button--green.file-custom--button:focus i.dashing-tooltip:before,.button.button--border.button--green:focus i.dashing-clippy:before,.file-custom .button--border.button--green.file-custom--button:focus i.dashing-clippy:before,.button.button--border.button--green:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--green:focus .button--navigation:before,.file-custom .button--border.button--green.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--green.file-custom--button:focus .button--navigation:before,button.button--border.button--green:hover .dashing-icon:before,button.button--border.button--green:hover i.dashing-tooltip:before,button.button--border.button--green:hover i.dashing-clippy:before,button.button--border.button--green:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--green:hover .button--navigation:before,button.button--border.button--green:focus .dashing-icon:before,button.button--border.button--green:focus i.dashing-tooltip:before,button.button--border.button--green:focus i.dashing-clippy:before,button.button--border.button--green:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--green:focus .button--navigation:before,input[type='submit'].button--border.button--green:hover .dashing-icon:before,input[type='submit'].button--border.button--green:hover i.dashing-tooltip:before,input[type='submit'].button--border.button--green:hover i.dashing-clippy:before,input[type='submit'].button--border.button--green:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--green:hover .button--navigation:before,input[type='submit'].button--border.button--green:focus .dashing-icon:before,input[type='submit'].button--border.button--green:focus i.dashing-tooltip:before,input[type='submit'].button--border.button--green:focus i.dashing-clippy:before,input[type='submit'].button--border.button--green:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--green:focus .button--navigation:before,input[type='reset'].button--border.button--green:hover .dashing-icon:before,input[type='reset'].button--border.button--green:hover i.dashing-tooltip:before,input[type='reset'].button--border.button--green:hover i.dashing-clippy:before,input[type='reset'].button--border.button--green:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--green:hover .button--navigation:before,input[type='reset'].button--border.button--green:focus .dashing-icon:before,input[type='reset'].button--border.button--green:focus i.dashing-tooltip:before,input[type='reset'].button--border.button--green:focus i.dashing-clippy:before,input[type='reset'].button--border.button--green:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--green:focus .button--navigation:before{color:#fff;transition:all 50ms ease-in-out}.button.button--border.button--green:active,.file-custom .button--border.button--green.file-custom--button:active,button.button--border.button--green:active,input[type='submit'].button--border.button--green:active,input[type='reset'].button--border.button--green:active{background-color:#05613a}.button.button--border.button--red,.file-custom .button--border.button--red.file-custom--button,button.button--border.button--red,input[type='submit'].button--border.button--red,input[type='reset'].button--border.button--red{background-color:rgba(255,255,255,0);border-color:#DA3D30;color:#DA3D30}.button.button--border.button--red .dashing-icon:before,.file-custom .button--border.button--red.file-custom--button .dashing-icon:before,.button.button--border.button--red i.dashing-tooltip:before,.file-custom .button--border.button--red.file-custom--button i.dashing-tooltip:before,.button.button--border.button--red i.dashing-clippy:before,.file-custom .button--border.button--red.file-custom--button i.dashing-clippy:before,.button.button--border.button--red .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--red .button--navigation:before,.file-custom .button--border.button--red.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--red.file-custom--button .button--navigation:before,button.button--border.button--red .dashing-icon:before,button.button--border.button--red i.dashing-tooltip:before,button.button--border.button--red i.dashing-clippy:before,button.button--border.button--red .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--red .button--navigation:before,input[type='submit'].button--border.button--red .dashing-icon:before,input[type='submit'].button--border.button--red i.dashing-tooltip:before,input[type='submit'].button--border.button--red i.dashing-clippy:before,input[type='submit'].button--border.button--red .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--red .button--navigation:before,input[type='reset'].button--border.button--red .dashing-icon:before,input[type='reset'].button--border.button--red i.dashing-tooltip:before,input[type='reset'].button--border.button--red i.dashing-clippy:before,input[type='reset'].button--border.button--red .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--red .button--navigation:before{color:#DA3D30}.button.button--border.button--red:hover,.file-custom .button--border.button--red.file-custom--button:hover,.button.button--border.button--red:focus,.file-custom .button--border.button--red.file-custom--button:focus,button.button--border.button--red:hover,button.button--border.button--red:focus,input[type='submit'].button--border.button--red:hover,input[type='submit'].button--border.button--red:focus,input[type='reset'].button--border.button--red:hover,input[type='reset'].button--border.button--red:focus{background-color:#b62c21;border-color:rgba(255,255,255,0);color:#fff}.button.button--border.button--red:hover .dashing-icon:before,.file-custom .button--border.button--red.file-custom--button:hover .dashing-icon:before,.button.button--border.button--red:hover i.dashing-tooltip:before,.file-custom .button--border.button--red.file-custom--button:hover i.dashing-tooltip:before,.button.button--border.button--red:hover i.dashing-clippy:before,.file-custom .button--border.button--red.file-custom--button:hover i.dashing-clippy:before,.button.button--border.button--red:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--red:hover .button--navigation:before,.file-custom .button--border.button--red.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--red.file-custom--button:hover .button--navigation:before,.button.button--border.button--red:focus .dashing-icon:before,.file-custom .button--border.button--red.file-custom--button:focus .dashing-icon:before,.button.button--border.button--red:focus i.dashing-tooltip:before,.file-custom .button--border.button--red.file-custom--button:focus i.dashing-tooltip:before,.button.button--border.button--red:focus i.dashing-clippy:before,.file-custom .button--border.button--red.file-custom--button:focus i.dashing-clippy:before,.button.button--border.button--red:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--red:focus .button--navigation:before,.file-custom .button--border.button--red.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--red.file-custom--button:focus .button--navigation:before,button.button--border.button--red:hover .dashing-icon:before,button.button--border.button--red:hover i.dashing-tooltip:before,button.button--border.button--red:hover i.dashing-clippy:before,button.button--border.button--red:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--red:hover .button--navigation:before,button.button--border.button--red:focus .dashing-icon:before,button.button--border.button--red:focus i.dashing-tooltip:before,button.button--border.button--red:focus i.dashing-clippy:before,button.button--border.button--red:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--red:focus .button--navigation:before,input[type='submit'].button--border.button--red:hover .dashing-icon:before,input[type='submit'].button--border.button--red:hover i.dashing-tooltip:before,input[type='submit'].button--border.button--red:hover i.dashing-clippy:before,input[type='submit'].button--border.button--red:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--red:hover .button--navigation:before,input[type='submit'].button--border.button--red:focus .dashing-icon:before,input[type='submit'].button--border.button--red:focus i.dashing-tooltip:before,input[type='submit'].button--border.button--red:focus i.dashing-clippy:before,input[type='submit'].button--border.button--red:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--red:focus .button--navigation:before,input[type='reset'].button--border.button--red:hover .dashing-icon:before,input[type='reset'].button--border.button--red:hover i.dashing-tooltip:before,input[type='reset'].button--border.button--red:hover i.dashing-clippy:before,input[type='reset'].button--border.button--red:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--red:hover .button--navigation:before,input[type='reset'].button--border.button--red:focus .dashing-icon:before,input[type='reset'].button--border.button--red:focus i.dashing-tooltip:before,input[type='reset'].button--border.button--red:focus i.dashing-clippy:before,input[type='reset'].button--border.button--red:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--red:focus .button--navigation:before{color:#fff;transition:all 50ms ease-in-out}.button.button--border.button--red:active,.file-custom .button--border.button--red.file-custom--button:active,button.button--border.button--red:active,input[type='submit'].button--border.button--red:active,input[type='reset'].button--border.button--red:active{background-color:#a1271d}.button.button--border.button--orange,.file-custom .button--border.button--orange.file-custom--button,button.button--border.button--orange,input[type='submit'].button--border.button--orange,input[type='reset'].button--border.button--orange{background-color:rgba(255,255,255,0);border-color:#FFA11F;color:#FFA11F}.button.button--border.button--orange .dashing-icon:before,.file-custom .button--border.button--orange.file-custom--button .dashing-icon:before,.button.button--border.button--orange i.dashing-tooltip:before,.file-custom .button--border.button--orange.file-custom--button i.dashing-tooltip:before,.button.button--border.button--orange i.dashing-clippy:before,.file-custom .button--border.button--orange.file-custom--button i.dashing-clippy:before,.button.button--border.button--orange .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--orange .button--navigation:before,.file-custom .button--border.button--orange.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--orange.file-custom--button .button--navigation:before,button.button--border.button--orange .dashing-icon:before,button.button--border.button--orange i.dashing-tooltip:before,button.button--border.button--orange i.dashing-clippy:before,button.button--border.button--orange .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--orange .button--navigation:before,input[type='submit'].button--border.button--orange .dashing-icon:before,input[type='submit'].button--border.button--orange i.dashing-tooltip:before,input[type='submit'].button--border.button--orange i.dashing-clippy:before,input[type='submit'].button--border.button--orange .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--orange .button--navigation:before,input[type='reset'].button--border.button--orange .dashing-icon:before,input[type='reset'].button--border.button--orange i.dashing-tooltip:before,input[type='reset'].button--border.button--orange i.dashing-clippy:before,input[type='reset'].button--border.button--orange .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--orange .button--navigation:before{color:#FFA11F}.button.button--border.button--orange:hover,.file-custom .button--border.button--orange.file-custom--button:hover,.button.button--border.button--orange:focus,.file-custom .button--border.button--orange.file-custom--button:focus,button.button--border.button--orange:hover,button.button--border.button--orange:focus,input[type='submit'].button--border.button--orange:hover,input[type='submit'].button--border.button--orange:focus,input[type='reset'].button--border.button--orange:hover,input[type='reset'].button--border.button--orange:focus{background-color:#eb8800;border-color:rgba(255,255,255,0);color:#fff}.button.button--border.button--orange:hover .dashing-icon:before,.file-custom .button--border.button--orange.file-custom--button:hover .dashing-icon:before,.button.button--border.button--orange:hover i.dashing-tooltip:before,.file-custom .button--border.button--orange.file-custom--button:hover i.dashing-tooltip:before,.button.button--border.button--orange:hover i.dashing-clippy:before,.file-custom .button--border.button--orange.file-custom--button:hover i.dashing-clippy:before,.button.button--border.button--orange:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--orange:hover .button--navigation:before,.file-custom .button--border.button--orange.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--orange.file-custom--button:hover .button--navigation:before,.button.button--border.button--orange:focus .dashing-icon:before,.file-custom .button--border.button--orange.file-custom--button:focus .dashing-icon:before,.button.button--border.button--orange:focus i.dashing-tooltip:before,.file-custom .button--border.button--orange.file-custom--button:focus i.dashing-tooltip:before,.button.button--border.button--orange:focus i.dashing-clippy:before,.file-custom .button--border.button--orange.file-custom--button:focus i.dashing-clippy:before,.button.button--border.button--orange:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--orange:focus .button--navigation:before,.file-custom .button--border.button--orange.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--orange.file-custom--button:focus .button--navigation:before,button.button--border.button--orange:hover .dashing-icon:before,button.button--border.button--orange:hover i.dashing-tooltip:before,button.button--border.button--orange:hover i.dashing-clippy:before,button.button--border.button--orange:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--orange:hover .button--navigation:before,button.button--border.button--orange:focus .dashing-icon:before,button.button--border.button--orange:focus i.dashing-tooltip:before,button.button--border.button--orange:focus i.dashing-clippy:before,button.button--border.button--orange:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--orange:focus .button--navigation:before,input[type='submit'].button--border.button--orange:hover .dashing-icon:before,input[type='submit'].button--border.button--orange:hover i.dashing-tooltip:before,input[type='submit'].button--border.button--orange:hover i.dashing-clippy:before,input[type='submit'].button--border.button--orange:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--orange:hover .button--navigation:before,input[type='submit'].button--border.button--orange:focus .dashing-icon:before,input[type='submit'].button--border.button--orange:focus i.dashing-tooltip:before,input[type='submit'].button--border.button--orange:focus i.dashing-clippy:before,input[type='submit'].button--border.button--orange:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--orange:focus .button--navigation:before,input[type='reset'].button--border.button--orange:hover .dashing-icon:before,input[type='reset'].button--border.button--orange:hover i.dashing-tooltip:before,input[type='reset'].button--border.button--orange:hover i.dashing-clippy:before,input[type='reset'].button--border.button--orange:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--orange:hover .button--navigation:before,input[type='reset'].button--border.button--orange:focus .dashing-icon:before,input[type='reset'].button--border.button--orange:focus i.dashing-tooltip:before,input[type='reset'].button--border.button--orange:focus i.dashing-clippy:before,input[type='reset'].button--border.button--orange:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--orange:focus .button--navigation:before{color:#fff;transition:all 50ms ease-in-out}.button.button--border.button--orange:active,.file-custom .button--border.button--orange.file-custom--button:active,button.button--border.button--orange:active,input[type='submit'].button--border.button--orange:active,input[type='reset'].button--border.button--orange:active{background-color:#d27a00}.button.button--border.button--purple,.file-custom .button--border.button--purple.file-custom--button,button.button--border.button--purple,input[type='submit'].button--border.button--purple,input[type='reset'].button--border.button--purple{background-color:rgba(255,255,255,0);border-color:#9F65AE;color:#9F65AE}.button.button--border.button--purple .dashing-icon:before,.file-custom .button--border.button--purple.file-custom--button .dashing-icon:before,.button.button--border.button--purple i.dashing-tooltip:before,.file-custom .button--border.button--purple.file-custom--button i.dashing-tooltip:before,.button.button--border.button--purple i.dashing-clippy:before,.file-custom .button--border.button--purple.file-custom--button i.dashing-clippy:before,.button.button--border.button--purple .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--purple .button--navigation:before,.file-custom .button--border.button--purple.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--purple.file-custom--button .button--navigation:before,button.button--border.button--purple .dashing-icon:before,button.button--border.button--purple i.dashing-tooltip:before,button.button--border.button--purple i.dashing-clippy:before,button.button--border.button--purple .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--purple .button--navigation:before,input[type='submit'].button--border.button--purple .dashing-icon:before,input[type='submit'].button--border.button--purple i.dashing-tooltip:before,input[type='submit'].button--border.button--purple i.dashing-clippy:before,input[type='submit'].button--border.button--purple .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--purple .button--navigation:before,input[type='reset'].button--border.button--purple .dashing-icon:before,input[type='reset'].button--border.button--purple i.dashing-tooltip:before,input[type='reset'].button--border.button--purple i.dashing-clippy:before,input[type='reset'].button--border.button--purple .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--purple .button--navigation:before{color:#9F65AE}.button.button--border.button--purple:hover,.file-custom .button--border.button--purple.file-custom--button:hover,.button.button--border.button--purple:focus,.file-custom .button--border.button--purple.file-custom--button:focus,button.button--border.button--purple:hover,button.button--border.button--purple:focus,input[type='submit'].button--border.button--purple:hover,input[type='submit'].button--border.button--purple:focus,input[type='reset'].button--border.button--purple:hover,input[type='reset'].button--border.button--purple:focus{background-color:#844d93;border-color:rgba(255,255,255,0);color:#fff}.button.button--border.button--purple:hover .dashing-icon:before,.file-custom .button--border.button--purple.file-custom--button:hover .dashing-icon:before,.button.button--border.button--purple:hover i.dashing-tooltip:before,.file-custom .button--border.button--purple.file-custom--button:hover i.dashing-tooltip:before,.button.button--border.button--purple:hover i.dashing-clippy:before,.file-custom .button--border.button--purple.file-custom--button:hover i.dashing-clippy:before,.button.button--border.button--purple:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--purple:hover .button--navigation:before,.file-custom .button--border.button--purple.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--purple.file-custom--button:hover .button--navigation:before,.button.button--border.button--purple:focus .dashing-icon:before,.file-custom .button--border.button--purple.file-custom--button:focus .dashing-icon:before,.button.button--border.button--purple:focus i.dashing-tooltip:before,.file-custom .button--border.button--purple.file-custom--button:focus i.dashing-tooltip:before,.button.button--border.button--purple:focus i.dashing-clippy:before,.file-custom .button--border.button--purple.file-custom--button:focus i.dashing-clippy:before,.button.button--border.button--purple:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--purple:focus .button--navigation:before,.file-custom .button--border.button--purple.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--purple.file-custom--button:focus .button--navigation:before,button.button--border.button--purple:hover .dashing-icon:before,button.button--border.button--purple:hover i.dashing-tooltip:before,button.button--border.button--purple:hover i.dashing-clippy:before,button.button--border.button--purple:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--purple:hover .button--navigation:before,button.button--border.button--purple:focus .dashing-icon:before,button.button--border.button--purple:focus i.dashing-tooltip:before,button.button--border.button--purple:focus i.dashing-clippy:before,button.button--border.button--purple:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--purple:focus .button--navigation:before,input[type='submit'].button--border.button--purple:hover .dashing-icon:before,input[type='submit'].button--border.button--purple:hover i.dashing-tooltip:before,input[type='submit'].button--border.button--purple:hover i.dashing-clippy:before,input[type='submit'].button--border.button--purple:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--purple:hover .button--navigation:before,input[type='submit'].button--border.button--purple:focus .dashing-icon:before,input[type='submit'].button--border.button--purple:focus i.dashing-tooltip:before,input[type='submit'].button--border.button--purple:focus i.dashing-clippy:before,input[type='submit'].button--border.button--purple:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--purple:focus .button--navigation:before,input[type='reset'].button--border.button--purple:hover .dashing-icon:before,input[type='reset'].button--border.button--purple:hover i.dashing-tooltip:before,input[type='reset'].button--border.button--purple:hover i.dashing-clippy:before,input[type='reset'].button--border.button--purple:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--purple:hover .button--navigation:before,input[type='reset'].button--border.button--purple:focus .dashing-icon:before,input[type='reset'].button--border.button--purple:focus i.dashing-tooltip:before,input[type='reset'].button--border.button--purple:focus i.dashing-clippy:before,input[type='reset'].button--border.button--purple:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--purple:focus .button--navigation:before{color:#fff;transition:all 50ms ease-in-out}.button.button--border.button--purple:active,.file-custom .button--border.button--purple.file-custom--button:active,button.button--border.button--purple:active,input[type='submit'].button--border.button--purple:active,input[type='reset'].button--border.button--purple:active{background-color:#754482}.button.button--border.button--gray,.file-custom .button--border.button--gray.file-custom--button,.button.button--border.button--secondary,.file-custom .button--border.button--secondary.file-custom--button,button.button--border.button--gray,button.button--border.button--secondary,input[type='submit'].button--border.button--gray,input[type='submit'].button--border.button--secondary,input[type='reset'].button--border.button--gray,input[type='reset'].button--border.button--secondary{background-color:rgba(255,255,255,0);color:#555;border-color:#878787}.button.button--border.button--gray:hover,.file-custom .button--border.button--gray.file-custom--button:hover,.button.button--border.button--gray:focus,.file-custom .button--border.button--gray.file-custom--button:focus,.button.button--border.button--secondary:hover,.file-custom .button--border.button--secondary.file-custom--button:hover,.button.button--border.button--secondary:focus,.file-custom .button--border.button--secondary.file-custom--button:focus,button.button--border.button--gray:hover,button.button--border.button--gray:focus,button.button--border.button--secondary:hover,button.button--border.button--secondary:focus,input[type='submit'].button--border.button--gray:hover,input[type='submit'].button--border.button--gray:focus,input[type='submit'].button--border.button--secondary:hover,input[type='submit'].button--border.button--secondary:focus,input[type='reset'].button--border.button--gray:hover,input[type='reset'].button--border.button--gray:focus,input[type='reset'].button--border.button--secondary:hover,input[type='reset'].button--border.button--secondary:focus{background-color:rgba(230,230,230,0);color:#555}.button.button--border.button--gray:active,.file-custom .button--border.button--gray.file-custom--button:active,.button.button--border.button--secondary:active,.file-custom .button--border.button--secondary.file-custom--button:active,button.button--border.button--gray:active,button.button--border.button--secondary:active,input[type='submit'].button--border.button--gray:active,input[type='submit'].button--border.button--secondary:active,input[type='reset'].button--border.button--gray:active,input[type='reset'].button--border.button--secondary:active{background-color:rgba(217,217,217,0)}.button.button--border.button--gray:not(.button--transparent) .dashing-icon:before,.file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--border.button--gray:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--border.button--gray:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--border.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--gray:not(.button--transparent) .button--navigation:before,.file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) .button--navigation:before,.button.button--border.button--secondary:not(.button--transparent) .dashing-icon:before,.file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) .dashing-icon:before,.button.button--border.button--secondary:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button.button--border.button--secondary:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button.button--border.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--secondary:not(.button--transparent) .button--navigation:before,.file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) .button--navigation:before,button.button--border.button--gray:not(.button--transparent) .dashing-icon:before,button.button--border.button--gray:not(.button--transparent) i.dashing-tooltip:before,button.button--border.button--gray:not(.button--transparent) i.dashing-clippy:before,button.button--border.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--gray:not(.button--transparent) .button--navigation:before,button.button--border.button--secondary:not(.button--transparent) .dashing-icon:before,button.button--border.button--secondary:not(.button--transparent) i.dashing-tooltip:before,button.button--border.button--secondary:not(.button--transparent) i.dashing-clippy:before,button.button--border.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--secondary:not(.button--transparent) .button--navigation:before,input[type='submit'].button--border.button--gray:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--border.button--gray:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--border.button--gray:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--border.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--gray:not(.button--transparent) .button--navigation:before,input[type='submit'].button--border.button--secondary:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--border.button--secondary:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--border.button--secondary:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--border.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--secondary:not(.button--transparent) .button--navigation:before,input[type='reset'].button--border.button--gray:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--border.button--gray:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--border.button--gray:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--border.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--gray:not(.button--transparent) .button--navigation:before,input[type='reset'].button--border.button--secondary:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--border.button--secondary:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--border.button--secondary:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--border.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--secondary:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--border.button--gray:hover,.file-custom .button--border.button--gray.file-custom--button:hover,.button.button--border.button--gray:focus,.file-custom .button--border.button--gray.file-custom--button:focus,.button.button--border.button--secondary:hover,.file-custom .button--border.button--secondary.file-custom--button:hover,.button.button--border.button--secondary:focus,.file-custom .button--border.button--secondary.file-custom--button:focus,button.button--border.button--gray:hover,button.button--border.button--gray:focus,button.button--border.button--secondary:hover,button.button--border.button--secondary:focus,input[type='submit'].button--border.button--gray:hover,input[type='submit'].button--border.button--gray:focus,input[type='submit'].button--border.button--secondary:hover,input[type='submit'].button--border.button--secondary:focus,input[type='reset'].button--border.button--gray:hover,input[type='reset'].button--border.button--gray:focus,input[type='reset'].button--border.button--secondary:hover,input[type='reset'].button--border.button--secondary:focus{background-color:#D4D4D4;color:#222;border-color:rgba(255,255,255,0)}.button.button--border.button--gray:hover:hover,.file-custom .button--border.button--gray.file-custom--button:hover:hover,.button.button--border.button--gray:hover:focus,.file-custom .button--border.button--gray.file-custom--button:hover:focus,.button.button--border.button--gray:focus:hover,.file-custom .button--border.button--gray.file-custom--button:focus:hover,.button.button--border.button--gray:focus:focus,.file-custom .button--border.button--gray.file-custom--button:focus:focus,.button.button--border.button--secondary:hover:hover,.file-custom .button--border.button--secondary.file-custom--button:hover:hover,.button.button--border.button--secondary:hover:focus,.file-custom .button--border.button--secondary.file-custom--button:hover:focus,.button.button--border.button--secondary:focus:hover,.file-custom .button--border.button--secondary.file-custom--button:focus:hover,.button.button--border.button--secondary:focus:focus,.file-custom .button--border.button--secondary.file-custom--button:focus:focus,button.button--border.button--gray:hover:hover,button.button--border.button--gray:hover:focus,button.button--border.button--gray:focus:hover,button.button--border.button--gray:focus:focus,button.button--border.button--secondary:hover:hover,button.button--border.button--secondary:hover:focus,button.button--border.button--secondary:focus:hover,button.button--border.button--secondary:focus:focus,input[type='submit'].button--border.button--gray:hover:hover,input[type='submit'].button--border.button--gray:hover:focus,input[type='submit'].button--border.button--gray:focus:hover,input[type='submit'].button--border.button--gray:focus:focus,input[type='submit'].button--border.button--secondary:hover:hover,input[type='submit'].button--border.button--secondary:hover:focus,input[type='submit'].button--border.button--secondary:focus:hover,input[type='submit'].button--border.button--secondary:focus:focus,input[type='reset'].button--border.button--gray:hover:hover,input[type='reset'].button--border.button--gray:hover:focus,input[type='reset'].button--border.button--gray:focus:hover,input[type='reset'].button--border.button--gray:focus:focus,input[type='reset'].button--border.button--secondary:hover:hover,input[type='reset'].button--border.button--secondary:hover:focus,input[type='reset'].button--border.button--secondary:focus:hover,input[type='reset'].button--border.button--secondary:focus:focus{background-color:#bbb;color:#222}.button.button--border.button--gray:hover:active,.file-custom .button--border.button--gray.file-custom--button:hover:active,.button.button--border.button--gray:focus:active,.file-custom .button--border.button--gray.file-custom--button:focus:active,.button.button--border.button--secondary:hover:active,.file-custom .button--border.button--secondary.file-custom--button:hover:active,.button.button--border.button--secondary:focus:active,.file-custom .button--border.button--secondary.file-custom--button:focus:active,button.button--border.button--gray:hover:active,button.button--border.button--gray:focus:active,button.button--border.button--secondary:hover:active,button.button--border.button--secondary:focus:active,input[type='submit'].button--border.button--gray:hover:active,input[type='submit'].button--border.button--gray:focus:active,input[type='submit'].button--border.button--secondary:hover:active,input[type='submit'].button--border.button--secondary:focus:active,input[type='reset'].button--border.button--gray:hover:active,input[type='reset'].button--border.button--gray:focus:active,input[type='reset'].button--border.button--secondary:hover:active,input[type='reset'].button--border.button--secondary:focus:active{background-color:#aeaeae}.button.button--border.button--gray:hover:not(.button--transparent) .dashing-icon:before,.file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) .dashing-icon:before,.button.button--border.button--gray:hover:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) i.dashing-tooltip:before,.button.button--border.button--gray:hover:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) i.dashing-clippy:before,.button.button--border.button--gray:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--gray:hover:not(.button--transparent) .button--navigation:before,.file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) .button--navigation:before,.button.button--border.button--gray:focus:not(.button--transparent) .dashing-icon:before,.file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) .dashing-icon:before,.button.button--border.button--gray:focus:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) i.dashing-tooltip:before,.button.button--border.button--gray:focus:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) i.dashing-clippy:before,.button.button--border.button--gray:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--gray:focus:not(.button--transparent) .button--navigation:before,.file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) .button--navigation:before,.button.button--border.button--secondary:hover:not(.button--transparent) .dashing-icon:before,.file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) .dashing-icon:before,.button.button--border.button--secondary:hover:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) i.dashing-tooltip:before,.button.button--border.button--secondary:hover:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) i.dashing-clippy:before,.button.button--border.button--secondary:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--secondary:hover:not(.button--transparent) .button--navigation:before,.file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) .button--navigation:before,.button.button--border.button--secondary:focus:not(.button--transparent) .dashing-icon:before,.file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) .dashing-icon:before,.button.button--border.button--secondary:focus:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) i.dashing-tooltip:before,.button.button--border.button--secondary:focus:not(.button--transparent) i.dashing-clippy:before,.file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) i.dashing-clippy:before,.button.button--border.button--secondary:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--secondary:focus:not(.button--transparent) .button--navigation:before,.file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) .button--navigation:before,button.button--border.button--gray:hover:not(.button--transparent) .dashing-icon:before,button.button--border.button--gray:hover:not(.button--transparent) i.dashing-tooltip:before,button.button--border.button--gray:hover:not(.button--transparent) i.dashing-clippy:before,button.button--border.button--gray:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--gray:hover:not(.button--transparent) .button--navigation:before,button.button--border.button--gray:focus:not(.button--transparent) .dashing-icon:before,button.button--border.button--gray:focus:not(.button--transparent) i.dashing-tooltip:before,button.button--border.button--gray:focus:not(.button--transparent) i.dashing-clippy:before,button.button--border.button--gray:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--gray:focus:not(.button--transparent) .button--navigation:before,button.button--border.button--secondary:hover:not(.button--transparent) .dashing-icon:before,button.button--border.button--secondary:hover:not(.button--transparent) i.dashing-tooltip:before,button.button--border.button--secondary:hover:not(.button--transparent) i.dashing-clippy:before,button.button--border.button--secondary:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--secondary:hover:not(.button--transparent) .button--navigation:before,button.button--border.button--secondary:focus:not(.button--transparent) .dashing-icon:before,button.button--border.button--secondary:focus:not(.button--transparent) i.dashing-tooltip:before,button.button--border.button--secondary:focus:not(.button--transparent) i.dashing-clippy:before,button.button--border.button--secondary:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--secondary:focus:not(.button--transparent) .button--navigation:before,input[type='submit'].button--border.button--gray:hover:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--border.button--gray:hover:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--border.button--gray:hover:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--border.button--gray:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--gray:hover:not(.button--transparent) .button--navigation:before,input[type='submit'].button--border.button--gray:focus:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--border.button--gray:focus:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--border.button--gray:focus:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--border.button--gray:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--gray:focus:not(.button--transparent) .button--navigation:before,input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) .button--navigation:before,input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) .dashing-icon:before,input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) i.dashing-tooltip:before,input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) i.dashing-clippy:before,input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) .button--navigation:before,input[type='reset'].button--border.button--gray:hover:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--border.button--gray:hover:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--border.button--gray:hover:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--border.button--gray:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--gray:hover:not(.button--transparent) .button--navigation:before,input[type='reset'].button--border.button--gray:focus:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--border.button--gray:focus:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--border.button--gray:focus:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--border.button--gray:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--gray:focus:not(.button--transparent) .button--navigation:before,input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) .button--navigation:before,input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) .dashing-icon:before,input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) i.dashing-tooltip:before,input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) i.dashing-clippy:before,input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) .button--navigation:before{color:#fff}.button.button--border.button--gray .dashing-icon:before,.file-custom .button--border.button--gray.file-custom--button .dashing-icon:before,.button.button--border.button--gray i.dashing-tooltip:before,.file-custom .button--border.button--gray.file-custom--button i.dashing-tooltip:before,.button.button--border.button--gray i.dashing-clippy:before,.file-custom .button--border.button--gray.file-custom--button i.dashing-clippy:before,.button.button--border.button--gray .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--gray .button--navigation:before,.file-custom .button--border.button--gray.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--gray.file-custom--button .button--navigation:before,.button.button--border.button--secondary .dashing-icon:before,.file-custom .button--border.button--secondary.file-custom--button .dashing-icon:before,.button.button--border.button--secondary i.dashing-tooltip:before,.file-custom .button--border.button--secondary.file-custom--button i.dashing-tooltip:before,.button.button--border.button--secondary i.dashing-clippy:before,.file-custom .button--border.button--secondary.file-custom--button i.dashing-clippy:before,.button.button--border.button--secondary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--secondary .button--navigation:before,.file-custom .button--border.button--secondary.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--secondary.file-custom--button .button--navigation:before,button.button--border.button--gray .dashing-icon:before,button.button--border.button--gray i.dashing-tooltip:before,button.button--border.button--gray i.dashing-clippy:before,button.button--border.button--gray .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--gray .button--navigation:before,button.button--border.button--secondary .dashing-icon:before,button.button--border.button--secondary i.dashing-tooltip:before,button.button--border.button--secondary i.dashing-clippy:before,button.button--border.button--secondary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--secondary .button--navigation:before,input[type='submit'].button--border.button--gray .dashing-icon:before,input[type='submit'].button--border.button--gray i.dashing-tooltip:before,input[type='submit'].button--border.button--gray i.dashing-clippy:before,input[type='submit'].button--border.button--gray .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--gray .button--navigation:before,input[type='submit'].button--border.button--secondary .dashing-icon:before,input[type='submit'].button--border.button--secondary i.dashing-tooltip:before,input[type='submit'].button--border.button--secondary i.dashing-clippy:before,input[type='submit'].button--border.button--secondary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--secondary .button--navigation:before,input[type='reset'].button--border.button--gray .dashing-icon:before,input[type='reset'].button--border.button--gray i.dashing-tooltip:before,input[type='reset'].button--border.button--gray i.dashing-clippy:before,input[type='reset'].button--border.button--gray .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--gray .button--navigation:before,input[type='reset'].button--border.button--secondary .dashing-icon:before,input[type='reset'].button--border.button--secondary i.dashing-tooltip:before,input[type='reset'].button--border.button--secondary i.dashing-clippy:before,input[type='reset'].button--border.button--secondary .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--secondary .button--navigation:before{color:#3B3B3B !important;transition:all 50ms ease-in-out}.button.button--border.button--white,.file-custom .button--border.button--white.file-custom--button,button.button--border.button--white,input[type='submit'].button--border.button--white,input[type='reset'].button--border.button--white{background-color:rgba(255,255,255,0);border-color:#fff;color:#fff}.button.button--border.button--white .dashing-icon:before,.file-custom .button--border.button--white.file-custom--button .dashing-icon:before,.button.button--border.button--white i.dashing-tooltip:before,.file-custom .button--border.button--white.file-custom--button i.dashing-tooltip:before,.button.button--border.button--white i.dashing-clippy:before,.file-custom .button--border.button--white.file-custom--button i.dashing-clippy:before,.button.button--border.button--white .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--white .button--navigation:before,.file-custom .button--border.button--white.file-custom--button .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button .button--navigation:before,button.button--border.button--white .dashing-icon:before,button.button--border.button--white i.dashing-tooltip:before,button.button--border.button--white i.dashing-clippy:before,button.button--border.button--white .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--white .button--navigation:before,input[type='submit'].button--border.button--white .dashing-icon:before,input[type='submit'].button--border.button--white i.dashing-tooltip:before,input[type='submit'].button--border.button--white i.dashing-clippy:before,input[type='submit'].button--border.button--white .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--white .button--navigation:before,input[type='reset'].button--border.button--white .dashing-icon:before,input[type='reset'].button--border.button--white i.dashing-tooltip:before,input[type='reset'].button--border.button--white i.dashing-clippy:before,input[type='reset'].button--border.button--white .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--white .button--navigation:before{color:#fff}.button.button--border.button--white:hover,.file-custom .button--border.button--white.file-custom--button:hover,.button.button--border.button--white:focus,.file-custom .button--border.button--white.file-custom--button:focus,button.button--border.button--white:hover,button.button--border.button--white:focus,input[type='submit'].button--border.button--white:hover,input[type='submit'].button--border.button--white:focus,input[type='reset'].button--border.button--white:hover,input[type='reset'].button--border.button--white:focus{background-color:#e6e6e6;border-color:rgba(255,255,255,0);color:#fff}.button.button--border.button--white:hover .dashing-icon:before,.file-custom .button--border.button--white.file-custom--button:hover .dashing-icon:before,.button.button--border.button--white:hover i.dashing-tooltip:before,.file-custom .button--border.button--white.file-custom--button:hover i.dashing-tooltip:before,.button.button--border.button--white:hover i.dashing-clippy:before,.file-custom .button--border.button--white.file-custom--button:hover i.dashing-clippy:before,.button.button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--white:hover .button--navigation:before,.file-custom .button--border.button--white.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button:hover .button--navigation:before,.button.button--border.button--white:focus .dashing-icon:before,.file-custom .button--border.button--white.file-custom--button:focus .dashing-icon:before,.button.button--border.button--white:focus i.dashing-tooltip:before,.file-custom .button--border.button--white.file-custom--button:focus i.dashing-tooltip:before,.button.button--border.button--white:focus i.dashing-clippy:before,.file-custom .button--border.button--white.file-custom--button:focus i.dashing-clippy:before,.button.button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--white:focus .button--navigation:before,.file-custom .button--border.button--white.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button:focus .button--navigation:before,button.button--border.button--white:hover .dashing-icon:before,button.button--border.button--white:hover i.dashing-tooltip:before,button.button--border.button--white:hover i.dashing-clippy:before,button.button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--white:hover .button--navigation:before,button.button--border.button--white:focus .dashing-icon:before,button.button--border.button--white:focus i.dashing-tooltip:before,button.button--border.button--white:focus i.dashing-clippy:before,button.button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--white:focus .button--navigation:before,input[type='submit'].button--border.button--white:hover .dashing-icon:before,input[type='submit'].button--border.button--white:hover i.dashing-tooltip:before,input[type='submit'].button--border.button--white:hover i.dashing-clippy:before,input[type='submit'].button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--white:hover .button--navigation:before,input[type='submit'].button--border.button--white:focus .dashing-icon:before,input[type='submit'].button--border.button--white:focus i.dashing-tooltip:before,input[type='submit'].button--border.button--white:focus i.dashing-clippy:before,input[type='submit'].button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--white:focus .button--navigation:before,input[type='reset'].button--border.button--white:hover .dashing-icon:before,input[type='reset'].button--border.button--white:hover i.dashing-tooltip:before,input[type='reset'].button--border.button--white:hover i.dashing-clippy:before,input[type='reset'].button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--white:hover .button--navigation:before,input[type='reset'].button--border.button--white:focus .dashing-icon:before,input[type='reset'].button--border.button--white:focus i.dashing-tooltip:before,input[type='reset'].button--border.button--white:focus i.dashing-clippy:before,input[type='reset'].button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--white:focus .button--navigation:before{color:#fff;transition:all 50ms ease-in-out}.button.button--border.button--white:active,.file-custom .button--border.button--white.file-custom--button:active,button.button--border.button--white:active,input[type='submit'].button--border.button--white:active,input[type='reset'].button--border.button--white:active{background-color:#d9d9d9}.button.button--border.button--white:hover,.file-custom .button--border.button--white.file-custom--button:hover,.button.button--border.button--white:focus,.file-custom .button--border.button--white.file-custom--button:focus,button.button--border.button--white:hover,button.button--border.button--white:focus,input[type='submit'].button--border.button--white:hover,input[type='submit'].button--border.button--white:focus,input[type='reset'].button--border.button--white:hover,input[type='reset'].button--border.button--white:focus{color:#3B3B3B !important}.button.button--border.button--white:hover .dashing-icon:before,.file-custom .button--border.button--white.file-custom--button:hover .dashing-icon:before,.button.button--border.button--white:hover i.dashing-tooltip:before,.file-custom .button--border.button--white.file-custom--button:hover i.dashing-tooltip:before,.button.button--border.button--white:hover i.dashing-clippy:before,.file-custom .button--border.button--white.file-custom--button:hover i.dashing-clippy:before,.button.button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--white:hover .button--navigation:before,.file-custom .button--border.button--white.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button:hover .button--navigation:before,.button.button--border.button--white:focus .dashing-icon:before,.file-custom .button--border.button--white.file-custom--button:focus .dashing-icon:before,.button.button--border.button--white:focus i.dashing-tooltip:before,.file-custom .button--border.button--white.file-custom--button:focus i.dashing-tooltip:before,.button.button--border.button--white:focus i.dashing-clippy:before,.file-custom .button--border.button--white.file-custom--button:focus i.dashing-clippy:before,.button.button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button.button--border.button--white:focus .button--navigation:before,.file-custom .button--border.button--white.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button:focus .button--navigation:before,button.button--border.button--white:hover .dashing-icon:before,button.button--border.button--white:hover i.dashing-tooltip:before,button.button--border.button--white:hover i.dashing-clippy:before,button.button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--white:hover .button--navigation:before,button.button--border.button--white:focus .dashing-icon:before,button.button--border.button--white:focus i.dashing-tooltip:before,button.button--border.button--white:focus i.dashing-clippy:before,button.button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title button.button--border.button--white:focus .button--navigation:before,input[type='submit'].button--border.button--white:hover .dashing-icon:before,input[type='submit'].button--border.button--white:hover i.dashing-tooltip:before,input[type='submit'].button--border.button--white:hover i.dashing-clippy:before,input[type='submit'].button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--white:hover .button--navigation:before,input[type='submit'].button--border.button--white:focus .dashing-icon:before,input[type='submit'].button--border.button--white:focus i.dashing-tooltip:before,input[type='submit'].button--border.button--white:focus i.dashing-clippy:before,input[type='submit'].button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='submit'].button--border.button--white:focus .button--navigation:before,input[type='reset'].button--border.button--white:hover .dashing-icon:before,input[type='reset'].button--border.button--white:hover i.dashing-tooltip:before,input[type='reset'].button--border.button--white:hover i.dashing-clippy:before,input[type='reset'].button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--white:hover .button--navigation:before,input[type='reset'].button--border.button--white:focus .dashing-icon:before,input[type='reset'].button--border.button--white:focus i.dashing-tooltip:before,input[type='reset'].button--border.button--white:focus i.dashing-clippy:before,input[type='reset'].button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title input[type='reset'].button--border.button--white:focus .button--navigation:before{color:#3B3B3B !important;transition:all 50ms ease-in-out}.button .dashing-icon.flow-opposite,.file-custom .file-custom--button .dashing-icon.flow-opposite,.button i.flow-opposite.dashing-tooltip,.file-custom .file-custom--button i.flow-opposite.dashing-tooltip,.button i.flow-opposite.dashing-clippy,.file-custom .file-custom--button i.flow-opposite.dashing-clippy,.button .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title .button .flow-opposite.button--navigation,.file-custom .file-custom--button .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title .file-custom .file-custom--button .flow-opposite.button--navigation,button .dashing-icon.flow-opposite,button i.flow-opposite.dashing-tooltip,button i.flow-opposite.dashing-clippy,button .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title button .flow-opposite.button--navigation,input[type='submit'] .dashing-icon.flow-opposite,input[type='submit'] i.flow-opposite.dashing-tooltip,input[type='submit'] i.flow-opposite.dashing-clippy,input[type='submit'] .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title input[type='submit'] .flow-opposite.button--navigation,input[type='reset'] .dashing-icon.flow-opposite,input[type='reset'] i.flow-opposite.dashing-tooltip,input[type='reset'] i.flow-opposite.dashing-clippy,input[type='reset'] .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title input[type='reset'] .flow-opposite.button--navigation{display:inline-block}.button--icon{border-radius:50px !important;padding:1rem}.button--icon.button--icon--small,.button--icon.button--small,.app-menu .app-context .app-title .button--icon.button--navigation{padding:0.6rem}.button--icon.button--transparent:hover,.button--icon.button--transparent:focus{background-color:rgba(110,110,110,0.2);color:rgba(255,255,255,0);opacity:1}.button--icon.button--transparent:hover:hover,.button--icon.button--transparent:hover:focus,.button--icon.button--transparent:focus:hover,.button--icon.button--transparent:focus:focus{background-color:rgba(85,85,85,0.2);color:rgba(255,255,255,0)}.button--icon.button--transparent:hover:active,.button--icon.button--transparent:focus:active{background-color:rgba(72,72,72,0.2)}.button--icon.button--transparent:hover:not(.button--transparent) .dashing-icon:before,.button--icon.button--transparent:hover:not(.button--transparent) i.dashing-tooltip:before,.button--icon.button--transparent:hover:not(.button--transparent) i.dashing-clippy:before,.button--icon.button--transparent:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button--icon.button--transparent:hover:not(.button--transparent) .button--navigation:before,.button--icon.button--transparent:focus:not(.button--transparent) .dashing-icon:before,.button--icon.button--transparent:focus:not(.button--transparent) i.dashing-tooltip:before,.button--icon.button--transparent:focus:not(.button--transparent) i.dashing-clippy:before,.button--icon.button--transparent:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button--icon.button--transparent:focus:not(.button--transparent) .button--navigation:before{color:#fff}.button ~ .action,.file-custom .file-custom--button ~ .action{margin-left:0.5rem}.button-group{margin:0;padding:0;overflow:auto}.button-group.button-group--gray .button,.button-group.button-group--gray .file-custom .file-custom--button,.file-custom .button-group.button-group--gray .file-custom--button,.button-group.button-group--grey .button,.button-group.button-group--grey .file-custom .file-custom--button,.file-custom .button-group.button-group--grey .file-custom--button{background-color:#D4D4D4;color:#222}.button-group.button-group--gray .button:hover,.button-group.button-group--gray .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--gray .file-custom--button:hover,.button-group.button-group--gray .button:focus,.button-group.button-group--gray .file-custom .file-custom--button:focus,.file-custom .button-group.button-group--gray .file-custom--button:focus,.button-group.button-group--grey .button:hover,.button-group.button-group--grey .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--grey .file-custom--button:hover,.button-group.button-group--grey .button:focus,.button-group.button-group--grey .file-custom .file-custom--button:focus,.file-custom .button-group.button-group--grey .file-custom--button:focus{background-color:#bbb;color:#222}.button-group.button-group--gray .button:active,.button-group.button-group--gray .file-custom .file-custom--button:active,.file-custom .button-group.button-group--gray .file-custom--button:active,.button-group.button-group--grey .button:active,.button-group.button-group--grey .file-custom .file-custom--button:active,.file-custom .button-group.button-group--grey .file-custom--button:active{background-color:#aeaeae}.button-group.button-group--gray .button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before,.file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--gray .button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--gray .button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--gray .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--gray .button:not(.button--transparent) .button--navigation:before,.button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before,.file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) .button--navigation:before,.button-group.button-group--grey .button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before,.file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--grey .button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--grey .button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--grey .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--grey .button:not(.button--transparent) .button--navigation:before,.button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before,.file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) .button--navigation:before{color:#fff}.button-group.button-group--gray .button--radio input:checked ~ label,.button-group.button-group--grey .button--radio input:checked ~ label{background-color:#878787;color:#fff}.button-group.button-group--blue .button,.button-group.button-group--blue .file-custom .file-custom--button,.file-custom .button-group.button-group--blue .file-custom--button{background-color:#3F70C9;color:#fff}.button-group.button-group--blue .button:hover,.button-group.button-group--blue .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--blue .file-custom--button:hover,.button-group.button-group--blue .button:focus,.button-group.button-group--blue .file-custom .file-custom--button:focus,.file-custom .button-group.button-group--blue .file-custom--button:focus{background-color:#2f59a6;color:#fff}.button-group.button-group--blue .button:active,.button-group.button-group--blue .file-custom .file-custom--button:active,.file-custom .button-group.button-group--blue .file-custom--button:active{background-color:#294f92}.button-group.button-group--blue .button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before,.file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--blue .button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--blue .button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--blue .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--blue .button:not(.button--transparent) .button--navigation:before,.button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before,.file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) .button--navigation:before{color:#fff}.button-group.button-group--blue .button--radio input:checked ~ label{background-color:#375AA0}.button-group.button-group--green .button,.button-group.button-group--green .file-custom .file-custom--button,.file-custom .button-group.button-group--green .file-custom--button{background-color:#09AA66;color:#fff}.button-group.button-group--green .button:hover,.button-group.button-group--green .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--green .file-custom--button:hover,.button-group.button-group--green .button:focus,.button-group.button-group--green .file-custom .file-custom--button:focus,.file-custom .button-group.button-group--green .file-custom--button:focus{background-color:#067a49;color:#fff}.button-group.button-group--green .button:active,.button-group.button-group--green .file-custom .file-custom--button:active,.file-custom .button-group.button-group--green .file-custom--button:active{background-color:#05613a}.button-group.button-group--green .button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before,.file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--green .button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--green .button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--green .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--green .button:not(.button--transparent) .button--navigation:before,.button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before,.file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) .button--navigation:before{color:#fff}.button-group.button-group--green .button--radio input:checked ~ label{background-color:#007E39}.button-group.button-group--orange .button,.button-group.button-group--orange .file-custom .file-custom--button,.file-custom .button-group.button-group--orange .file-custom--button{background-color:#FFA11F;color:#fff}.button-group.button-group--orange .button:hover,.button-group.button-group--orange .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--orange .file-custom--button:hover,.button-group.button-group--orange .button:focus,.button-group.button-group--orange .file-custom .file-custom--button:focus,.file-custom .button-group.button-group--orange .file-custom--button:focus{background-color:#eb8800;color:#fff}.button-group.button-group--orange .button:active,.button-group.button-group--orange .file-custom .file-custom--button:active,.file-custom .button-group.button-group--orange .file-custom--button:active{background-color:#d27a00}.button-group.button-group--orange .button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before,.file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--orange .button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--orange .button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--orange .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--orange .button:not(.button--transparent) .button--navigation:before,.button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before,.file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) .button--navigation:before{color:#fff}.button-group.button-group--orange .button--radio input:checked ~ label{background-color:#AA6000}.button-group.button-group--purple .button,.button-group.button-group--purple .file-custom .file-custom--button,.file-custom .button-group.button-group--purple .file-custom--button{background-color:#9F65AE;color:#fff}.button-group.button-group--purple .button:hover,.button-group.button-group--purple .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--purple .file-custom--button:hover,.button-group.button-group--purple .button:focus,.button-group.button-group--purple .file-custom .file-custom--button:focus,.file-custom .button-group.button-group--purple .file-custom--button:focus{background-color:#844d93;color:#fff}.button-group.button-group--purple .button:active,.button-group.button-group--purple .file-custom .file-custom--button:active,.file-custom .button-group.button-group--purple .file-custom--button:active{background-color:#754482}.button-group.button-group--purple .button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before,.file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--purple .button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--purple .button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--purple .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--purple .button:not(.button--transparent) .button--navigation:before,.button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before,.file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) .button--navigation:before{color:#fff}.button-group.button-group--purple .button--radio input:checked ~ label{background-color:#290036}.button-group.button-group--red .button,.button-group.button-group--red .file-custom .file-custom--button,.file-custom .button-group.button-group--red .file-custom--button{background-color:#DA3D30;color:#fff}.button-group.button-group--red .button:hover,.button-group.button-group--red .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--red .file-custom--button:hover,.button-group.button-group--red .button:focus,.button-group.button-group--red .file-custom .file-custom--button:focus,.file-custom .button-group.button-group--red .file-custom--button:focus{background-color:#b62c21;color:#fff}.button-group.button-group--red .button:active,.button-group.button-group--red .file-custom .file-custom--button:active,.file-custom .button-group.button-group--red .file-custom--button:active{background-color:#a1271d}.button-group.button-group--red .button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before,.file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) .dashing-icon:before,.button-group.button-group--red .button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,.button-group.button-group--red .button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) i.dashing-clippy:before,.button-group.button-group--red .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--red .button:not(.button--transparent) .button--navigation:before,.button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before,.file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) .button--navigation:before{color:#fff}.button-group.button-group--red .button--radio input:checked ~ label{background-color:#910000}.button-group.button-group--border .button--radio:first-of-type .button,.button-group.button-group--border .button--radio:first-of-type .file-custom .file-custom--button,.file-custom .button-group.button-group--border .button--radio:first-of-type .file-custom--button{border-left:2px solid #BABABA}.button-group.button-group--border .button--radio:first-of-type input:checked ~ label{border-color:#09AA66}.button-group.button-group--border .button--radio:last-of-type .button,.button-group.button-group--border .button--radio:last-of-type .file-custom .file-custom--button,.file-custom .button-group.button-group--border .button--radio:last-of-type .file-custom--button{border-right:2px solid #BABABA}.button-group.button-group--border .button--radio:last-of-type input:checked ~ label{border-color:#09AA66}.button-group.button-group--border .button,.button-group.button-group--border .file-custom .file-custom--button,.file-custom .button-group.button-group--border .file-custom--button{border:2px solid #BABABA;display:inline-block;padding:0.4rem 0.9rem;padding-top:0.35rem}.button-group.button-group--border.button-group--gray .button--radio input:checked ~ label,.button-group.button-group--border.button-group--grey .button--radio input:checked ~ label{background-color:#6E6E6E;border-color:#6E6E6E;color:#fff}.button-group.button-group--border.button-group--gray .button--radio input:checked ~ label:hover,.button-group.button-group--border.button-group--grey .button--radio input:checked ~ label:hover{color:#fff}.button-group.button-group--border.button-group--gray .button--radio .button,.button-group.button-group--border.button-group--gray .button--radio .file-custom .file-custom--button,.file-custom .button-group.button-group--border.button-group--gray .button--radio .file-custom--button,.button-group.button-group--border.button-group--grey .button--radio .button,.button-group.button-group--border.button-group--grey .button--radio .file-custom .file-custom--button,.file-custom .button-group.button-group--border.button-group--grey .button--radio .file-custom--button{background-color:transparent;color:#6E6E6E}.button-group.button-group--border.button-group--gray .button--radio .button:hover,.button-group.button-group--border.button-group--gray .button--radio .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--border.button-group--gray .button--radio .file-custom--button:hover,.button-group.button-group--border.button-group--grey .button--radio .button:hover,.button-group.button-group--border.button-group--grey .button--radio .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--border.button-group--grey .button--radio .file-custom--button:hover{color:#6E6E6E}.button-group.button-group--border.button-group--blue .button--radio input:checked ~ label{background-color:#3F70C9;border-color:#3F70C9;color:#fff}.button-group.button-group--border.button-group--blue .button--radio input:checked ~ label:hover{color:#fff}.button-group.button-group--border.button-group--blue .button--radio .button,.button-group.button-group--border.button-group--blue .button--radio .file-custom .file-custom--button,.file-custom .button-group.button-group--border.button-group--blue .button--radio .file-custom--button{background-color:transparent;color:#6E6E6E}.button-group.button-group--border.button-group--blue .button--radio .button:hover,.button-group.button-group--border.button-group--blue .button--radio .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--border.button-group--blue .button--radio .file-custom--button:hover{color:#3F70C9}.button-group.button-group--border.button-group--green .button--radio input:checked ~ label{background-color:#09AA66;border-color:#09AA66;color:#fff}.button-group.button-group--border.button-group--green .button--radio input:checked ~ label:hover{color:#fff}.button-group.button-group--border.button-group--green .button--radio .button,.button-group.button-group--border.button-group--green .button--radio .file-custom .file-custom--button,.file-custom .button-group.button-group--border.button-group--green .button--radio .file-custom--button{background-color:transparent;color:#6E6E6E}.button-group.button-group--border.button-group--green .button--radio .button:hover,.button-group.button-group--border.button-group--green .button--radio .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--border.button-group--green .button--radio .file-custom--button:hover{color:#09AA66}.button-group.button-group--border.button-group--orange .button--radio input:checked ~ label{background-color:#FFA11F;border-color:#FFA11F;color:#fff}.button-group.button-group--border.button-group--orange .button--radio input:checked ~ label:hover{color:#fff}.button-group.button-group--border.button-group--orange .button--radio .button,.button-group.button-group--border.button-group--orange .button--radio .file-custom .file-custom--button,.file-custom .button-group.button-group--border.button-group--orange .button--radio .file-custom--button{background-color:transparent;color:#6E6E6E}.button-group.button-group--border.button-group--orange .button--radio .button:hover,.button-group.button-group--border.button-group--orange .button--radio .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--border.button-group--orange .button--radio .file-custom--button:hover{color:#FFA11F}.button-group.button-group--border.button-group--purple .button--radio input:checked ~ label{background-color:#9F65AE;border-color:#9F65AE;color:#fff}.button-group.button-group--border.button-group--purple .button--radio input:checked ~ label:hover{color:#fff}.button-group.button-group--border.button-group--purple .button--radio .button,.button-group.button-group--border.button-group--purple .button--radio .file-custom .file-custom--button,.file-custom .button-group.button-group--border.button-group--purple .button--radio .file-custom--button{background-color:transparent;color:#6E6E6E}.button-group.button-group--border.button-group--purple .button--radio .button:hover,.button-group.button-group--border.button-group--purple .button--radio .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--border.button-group--purple .button--radio .file-custom--button:hover{color:#9F65AE}.button-group.button-group--border.button-group--red .button--radio input:checked ~ label{background-color:#DA3D30;border-color:#DA3D30;color:#fff}.button-group.button-group--border.button-group--red .button--radio input:checked ~ label:hover{color:#fff}.button-group.button-group--border.button-group--red .button--radio .button,.button-group.button-group--border.button-group--red .button--radio .file-custom .file-custom--button,.file-custom .button-group.button-group--border.button-group--red .button--radio .file-custom--button{background-color:transparent;color:#6E6E6E}.button-group.button-group--border.button-group--red .button--radio .button:hover,.button-group.button-group--border.button-group--red .button--radio .file-custom .file-custom--button:hover,.file-custom .button-group.button-group--border.button-group--red .button--radio .file-custom--button:hover{color:#DA3D30}.button-group .button--radio{display:inline-block;float:left}.button-group .button--radio:first-of-type label{margin-left:0}.button-group .button--radio input{display:none}.button-group .button--radio label{border-radius:0;display:inline-block;margin:0 0 0 -2px}@media all and (max-width: 40em){.button-group .button--radio label{border-left:1px}}.button-group.button-group--vertical{display:-webkit-inline-box;display:-moz-inline-box;display:-ms-inline-flexbox;display:-webkit-inline-flex;display:inline-flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-moz-box-orient:vertical;-moz-box-direction:normal;-ms-flex-direction:column;-webkit-flex-direction:column;flex-direction:column}.button-group.button-group--vertical .button--radio{display:block}.button-group.button-group--vertical .button--radio:first-of-type label{margin-top:2px}.button-group.button-group--vertical .button--radio:last-of-type label{margin-bottom:2px}.button-group.button-group--vertical .button--radio label{display:block !important;border-width:2px;margin:-1px auto}@media all and (max-width: 40em){.button-group.button-group--vertical_phone{display:-webkit-inline-box;display:-moz-inline-box;display:-ms-inline-flexbox;display:-webkit-inline-flex;display:inline-flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-moz-box-orient:vertical;-moz-box-direction:normal;-ms-flex-direction:column;-webkit-flex-direction:column;flex-direction:column}.button-group.button-group--vertical_phone .button--radio{display:block}.button-group.button-group--vertical_phone .button--radio:first-of-type label{margin-top:2px}.button-group.button-group--vertical_phone .button--radio:last-of-type label{margin-bottom:2px}.button-group.button-group--vertical_phone .button--radio label{display:block !important;border-width:2px;margin:-1px auto}}@media all and (min-width: 40em){.button-group.button-group--vertical_tablet{display:-webkit-inline-box;display:-moz-inline-box;display:-ms-inline-flexbox;display:-webkit-inline-flex;display:inline-flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-moz-box-orient:vertical;-moz-box-direction:normal;-ms-flex-direction:column;-webkit-flex-direction:column;flex-direction:column}.button-group.button-group--vertical_tablet .button--radio{display:block}.button-group.button-group--vertical_tablet .button--radio:first-of-type label{margin-top:2px}.button-group.button-group--vertical_tablet .button--radio:last-of-type label{margin-bottom:2px}.button-group.button-group--vertical_tablet .button--radio label{display:block !important;border-width:2px;margin:-1px auto}}.button-group .button--radio:first-of-type label{border-radius:50px 0 0 50px}.button-group .button--radio:last-of-type label{border-radius:0 50px 50px 0}.button-group.button--smooth .button--radio:first-of-type label,.app-menu .app-context .app-title .button-group.button--navigation .button--radio:first-of-type label{border-radius:5px 0 0 5px}.button-group.button--smooth .button--radio:last-of-type label,.app-menu .app-context .app-title .button-group.button--navigation .button--radio:last-of-type label{border-radius:0 5px 5px 0}.button-group.button--square .button--radio:first-of-type label,.button-group.button--square .button--radio:last-of-type label{border-radius:0}.button-group.button-group--vertical .button--radio:first-of-type label{border-radius:10px 10px 0 0}.button-group.button-group--vertical .button--radio:last-of-type label{border-radius:0 0 10px 10px}.button-group.button-group--vertical.button--smooth .button--radio:first-of-type label,.app-menu .app-context .app-title .button-group.button-group--vertical.button--navigation .button--radio:first-of-type label{border-radius:5px 5px 0 0}.button-group.button-group--vertical.button--smooth .button--radio:last-of-type label,.app-menu .app-context .app-title .button-group.button-group--vertical.button--navigation .button--radio:last-of-type label{border-radius:0 0 5px 5px}.button-group.button-group--vertical.button--square .button--radio:first-of-type label,.button-group.button-group--vertical.button--square .button--radio:last-of-type label{border-radius:0}@media all and (max-width: 40em){.button-group.button-group--vertical_phone .button--radio:first-of-type label{border-radius:10px 10px 0 0}.button-group.button-group--vertical_phone .button--radio:last-of-type label{border-radius:0 0 10px 10px}.button-group.button-group--vertical_phone.button--smooth .button--radio:first-of-type label,.app-menu .app-context .app-title .button-group.button-group--vertical_phone.button--navigation .button--radio:first-of-type label{border-radius:5px 5px 0 0}.button-group.button-group--vertical_phone.button--smooth .button--radio:last-of-type label,.app-menu .app-context .app-title .button-group.button-group--vertical_phone.button--navigation .button--radio:last-of-type label{border-radius:0 0 5px 5px}.button-group.button-group--vertical_phone.button--square .button--radio:first-of-type label,.button-group.button-group--vertical_phone.button--square .button--radio:last-of-type label{border-radius:0}}@media all and (min-width: 40em){.button-group.button-group--vertical_tablet .button--radio:first-of-type label{border-radius:10px 10px 0 0}.button-group.button-group--vertical_tablet .button--radio:last-of-type label{border-radius:0 0 10px 10px}.button-group.button-group--vertical_tablet.button--smooth .button--radio:first-of-type label,.app-menu .app-context .app-title .button-group.button-group--vertical_tablet.button--navigation .button--radio:first-of-type label{border-radius:5px 5px 0 0}.button-group.button-group--vertical_tablet.button--smooth .button--radio:last-of-type label,.app-menu .app-context .app-title .button-group.button-group--vertical_tablet.button--navigation .button--radio:last-of-type label{border-radius:0 0 5px 5px}.button-group.button-group--vertical_tablet.button--square .button--radio:first-of-type label,.button-group.button-group--vertical_tablet.button--square .button--radio:last-of-type label{border-radius:0}}.has-tooltip{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none}i.dashing-tooltip,i.dashing-clippy{cursor:help;display:inline-block}@media all and (max-width: 40em){i.dashing-tooltip,i.dashing-clippy{margin:-0.6rem -0.4rem !important;padding:0.6rem;border-radius:50px}i.dashing-tooltip:hover,i.dashing-clippy:hover{background-color:rgba(85,85,85,0.1)}}span .dashing-tooltip,p .dashing-tooltip{margin-left:0.2rem}span.dashing-tooltip{display:inline-block}.card{background-color:#fff;border:2px solid #D4D4D4;border-radius:10px;margin:1.5rem auto}.card .card--header hr,.card.card--content hr,.card.card--footer hr,.card .card-header hr,.card.card-content hr,.card.card-footer hr{margin:1rem 0}.card hr{margin:0}.card .card--header,.card .card-header{padding:1rem 1rem 0 1rem;padding-bottom:0}.card .card--header.has-border,.card .card-header.has-border{border-bottom:2px solid #D4D4D4;padding-bottom:1rem}.card .card--header.has-border+.card--content .card-banner,.card .card--header.has-border+.card-content .card-banner,.card .card-header.has-border+.card--content .card-banner,.card .card-header.has-border+.card-content .card-banner{margin-top:-1rem}.card .card--content,.card .card-content{overflow:auto;padding:1rem}.card .card--footer,.card .card-footer{padding:0 1rem 1rem 1rem}.card .card--footer.has-border,.card .card-footer.has-border{border-top:2px solid #D4D4D4;padding-top:1rem}.card--header+.card.card--footer,.card-header+.card.card-footer{padding-top:1rem}.card.is-selectable{transition:box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out}.card.is-selectable:hover{border-color:#3F70C9;cursor:pointer}.card.disabled,.card.is-disabled,.card.is-selectable.is-disabled,.card.is-selectable.disabled{opacity:0.4;pointer-events:none;background-color:#D4D4D4;border-color:#A1A1A1}.card.card--dashed{border-style:dashed}.card .card--narrow{max-width:750px}.prevent-scrolling{overflow:hidden}.dash-overlay{background-color:rgba(0,0,0,0.8);overflow-x:hidden;overflow-y:auto;-webkit-overflow-scrolling:touch;position:fixed;top:0;right:0;bottom:0;left:0;z-index:1000}.dash-overlay.is-locked{overflow:hidden}.dash-modal{background-color:#fff;border-radius:15px;margin:1.5rem auto;max-width:35rem;outline:0;width:90%;z-index:1050;cursor:default;overflow:hidden}@media all and (min-width: 40em){.dash-modal{margin:5rem auto 5rem auto}}.dash-modal.modal-small{max-width:25rem}.dash-modal.modal-large{max-width:45rem}.dash-modal .modal-header,.dash-modal .modal-content,.dash-modal .modal-footer{padding:1rem}.dash-modal .modal-header hr,.dash-modal .modal-content hr,.dash-modal .modal-footer hr{border:none;border-bottom:2px solid #E0E0E0;margin:1rem -1rem}.dash-modal .modal-close{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;float:right;font-size:1.5rem;position:relative;right:.7rem;top:.7rem;cursor:pointer;margin-left:-2rem}.dash-modal .modal-header{border-bottom:2px solid #E0E0E0;text-align:center}.dash-modal .modal-content p{line-height:1.4rem}.dash-modal .modal-content.has-video{padding:0;position:relative;padding-bottom:56.3%;height:0;overflow:hidden;max-width:100%;transform:translateY(0)}.dash-modal .modal-content.has-video iframe{position:absolute;top:0;left:0;width:100%;height:100%}.dash-modal .modal-footer{background-color:#EDEDED}.dash-modal .dashing-icon--close:before{color:#555 !important}.page-banner{background-color:#E0E0E0;text-align:center;padding:2rem 1rem;position:absolute;top:0;left:0;width:100%}.page-banner h4{color:#555;margin-top:0.5rem}.page-banner .button--banner{background-color:#A1A1A1;color:#fff;position:absolute;top:2.15rem;right:1rem}.page-banner .button--banner:hover,.page-banner .button--banner:focus{background-color:#888;color:#fff}.page-banner .button--banner:active{background-color:#7b7b7b}.page-banner .button--banner:not(.button--transparent) .dashing-icon:before,.page-banner .button--banner:not(.button--transparent) i.dashing-tooltip:before,.page-banner .button--banner:not(.button--transparent) i.dashing-clippy:before,.page-banner .button--banner:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .page-banner .button--banner:not(.button--transparent) .button--navigation:before{color:#fff}.card-banner{align-items:baseline;background-color:#D4D4D4;display:flex;padding:1rem;margin:0 -1rem}.card-banner.has-button{padding:.5rem 1rem;align-items:center}.card-banner.has-button button{white-space:nowrap}.card-banner.has-button p{margin-right:1rem}.card-banner a{border-bottom:solid 2px;color:inherit;cursor:pointer}.card-banner a:hover{opacity:0.6;transition:all 50ms ease-in-out}.card-banner.has-success p,.card-banner.has-error p{color:#fff}.card-banner.has-success .dashing-icon:before,.card-banner.has-success i.dashing-tooltip:before,.card-banner.has-success i.dashing-clippy:before,.card-banner.has-success .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .card-banner.has-success .button--navigation:before,.card-banner.has-error .dashing-icon:before,.card-banner.has-error i.dashing-tooltip:before,.card-banner.has-error i.dashing-clippy:before,.card-banner.has-error .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .card-banner.has-error .button--navigation:before{color:#fff}.card-banner.has-warning p{color:#000}.card-banner.has-warning .dashing-icon:before,.card-banner.has-warning i.dashing-tooltip:before,.card-banner.has-warning i.dashing-clippy:before,.card-banner.has-warning .app-menu .app-context .app-title .button--navigation:before,.app-menu .app-context .app-title .card-banner.has-warning .button--navigation:before{color:#000}.card-banner.has-success{background-color:#09AA66}.card-banner.has-warning{background-color:#FFA11F}.card-banner.has-error{background-color:#DA3D30}.card-banner .dashing-icon,.card-banner i.dashing-tooltip,.card-banner i.dashing-clippy,.card-banner .app-menu .app-context .app-title .button--navigation,.app-menu .app-context .app-title .card-banner .button--navigation{margin-right:0.5rem}.card-banner p{font-size:0.9rem;font-weight:600;margin:0}.table--container .table{background-color:#fff;font-size:.9rem;margin:0;max-width:100%;width:100%}.table--container .table thead tr{background-color:#fff}.table--container .table th,.table--container .table td{padding:1rem;text-align:left}.table--container .table td{vertical-align:middle}.table--container .table th{border-bottom:2px solid #D4D4D4}@media all and (min-width: 40em){.table--container.has-border{border:2px solid #D4D4D4;border-radius:10px;overflow:hidden}}.table.has-dividers td,.table.has-divider td{border-bottom:2px solid #EDEDED}.table.has-dividers tr:last-of-type td,.table.has-divider tr:last-of-type td{border-bottom:none}.table.has-row-color tr:nth-child(odd){background-color:#F2F2F2}.table.has-row-color tr:nth-child(even){background-color:#fff}.table.has-row-color thead tr:nth-child(odd){background-color:#fff}.table.has-row-color.has-hover tr:nth-child(odd):hover td{background-color:#e0e0e0}.table.has-row-color.has-hover tr:nth-child(even):hover td{background-color:#ededed}.table.has-hover td{-webkit-transition:all 0.15s ease-in-out;-moz-transition:all 0.15s ease-in-out;-o-transition:all 0.15s ease-in-out;-ms-transition:all 0.15s ease-in-out;transition:all 0.15s ease-in-out}.table.has-hover tr:hover td{background-color:#EDEDED}.table.has-hover tr.disabled:hover td{background-color:transparent;cursor:not-allowed}.app-menu{background-color:rgba(237,237,237,0.97);box-shadow:0 2px 6px #D4D4D4;height:auto !important;position:absolute;top:0;left:0;width:100%;z-index:10}.app-menu .app-context{max-width:1200px;margin:auto;padding:1rem}.app-menu .app-context .app-title{color:#222;font-size:1.25rem;font-weight:600}.app-menu .app-context .app-title a{color:#222}.app-menu .app-context .app-title a:hover{color:rgba(34,34,34,0.6)}.app-menu .app-context .app-title a.app-title--has-breadcrumb{color:rgba(34,34,34,0.5);cursor:pointer;transition:all 0.2s ease-in-out}.app-menu .app-context .app-title a.app-title--has-breadcrumb:hover{color:#222}.app-menu .app-context .app-title .button--navigation{background-color:#d9d9d9;color:#222;padding:0.4rem 0.55rem !important;position:relative;top:-3px;margin-right:0.5rem;text-decoration:none}.app-menu .app-context .app-title .button--navigation:hover,.app-menu .app-context .app-title .button--navigation:focus{background-color:#bfbfbf;color:#222}.app-menu .app-context .app-title .button--navigation:active{background-color:#b2b2b2}.app-menu .app-context .app-title .button--navigation:not(.button--transparent) .dashing-icon:before,.app-menu .app-context .app-title .button--navigation:not(.button--transparent) i.dashing-tooltip:before,.app-menu .app-context .app-title .button--navigation:not(.button--transparent) i.dashing-clippy:before,.app-menu .app-context .app-title .button--navigation:not(.button--transparent) .button--navigation:before{color:#fff}.app-menu .app-context .app-title .button--navigation:before{content:'\e82a';color:#222 !important;margin-right:0.35rem}.app-menu .app-context .app-title .button--navigation:after{content:'Back'}.app-menu .app-context ul.header-description{color:#222;float:right;position:relative;top:-1.4rem;height:0;margin:0;padding:0;list-style:none}.app-menu .app-context ul.header-description li{text-align:right;display:inline-block;font-weight:600;margin-right:1rem}.app-menu .app-context ul.header-description li:last-of-type{margin-right:0}.app-menu .app-context ul.header-description li .header-description--label,.app-menu .app-context ul.header-description li .header-description--content{display:block}.app-menu .app-context ul.header-description li .header-description--label{font-size:.8rem}.app-menu .app-context ul.header-description li .header-description--content{font-size:1.25rem}.app-menu .app-navigation{max-width:1200px;margin:auto;overflow:hidden;overflow-x:auto;padding:0 1rem;white-space:nowrap}.app-menu .app-navigation li,.app-menu .app-navigation a{border-bottom:4px solid transparent;padding-bottom:0.5rem}.app-menu .app-navigation li{display:inline-block;float:none}.app-menu .app-navigation li.active a,.app-menu .app-navigation li a.active,.app-menu .app-navigation li.is-active a,.app-menu .app-navigation li a.is-active{color:#222 !important;border-bottom:4px solid !important}.app-menu .app-navigation li a{color:rgba(34,34,34,0.6);font-size:1rem;line-height:0.9rem;margin:0;margin-right:1.2rem !important;transition:all 0.2s ease-in-out}.app-menu .app-navigation li a:hover{color:#222}.app-menu .app-navigation li a:hover .dashing-icon,.app-menu .app-navigation li a:hover i.dashing-tooltip,.app-menu .app-navigation li a:hover i.dashing-clippy,.app-menu .app-navigation li a:hover .app-context .app-title .button--navigation,.app-menu .app-context .app-title .app-navigation li a:hover .button--navigation{opacity:1}.app-menu .app-navigation li a .dashing-icon,.app-menu .app-navigation li a i.dashing-tooltip,.app-menu .app-navigation li a i.dashing-clippy,.app-menu .app-navigation li a .app-context .app-title .button--navigation,.app-menu .app-context .app-title .app-navigation li a .button--navigation{opacity:.6;transition:all 0.2s ease-in-out}.app-menu .dashing-icon--new-tab:before{color:rgba(34,34,34,0.9)}.app-menu .dashing-icon--arrow-right:before{color:rgba(34,34,34,0.5);font-size:12px;position:relative;top:-2px}.app-menu.condensed{height:4.6rem}.app-menu.expanded{height:7.05rem}.app-menu.fixed{position:fixed}.app-menu .button--icon--main{position:absolute;right:1rem;bottom:-1.5rem}@media screen and (min-width: 1200px){.app-menu .button--icon--main{right:calc(50% - (1200px/2) - 0.4rem)}}.app-menu.has-search .app-context{padding:0.5rem 1rem}@media all and (min-width: 40em){.app-menu.has-search .app-context{display:flex;align-items:center}}.app-menu.has-search .app-title{display:inline-block}.app-menu.has-search .search-input{padding-top:0.5rem}@media all and (min-width: 40em){.app-menu.has-search .search-input{margin-left:auto;padding-top:0rem;width:auto}}.app-menu.has-search fieldset input[type="text"]{border-color:transparent}.app-menu.has-search ~ .app-content{padding-top:5.75rem}@media all and (min-width: 40em){.app-menu.has-search ~ .app-content{padding-top:3.75rem}}.app-menu.expanded.has-search ~ .app-content{padding-top:8rem}@media all and (min-width: 40em){.app-menu.expanded.has-search ~ .app-content{padding-top:5.75rem}}.app-menu ~ .app-content{padding-top:4.6rem}.app-menu.expanded ~ .app-content{padding-top:7.05rem}.app-footer{background-color:rgba(255,255,255,0.95);border-top:2px solid #D4D4D4;box-shadow:0 -2px 30px 0 rgba(36,41,44,0.15);float:left;max-width:100%;padding:1rem;position:absolute;left:0;width:100%}.app-footer.fixed{position:fixed;bottom:0;left:0;right:0}.app-footer .row.no-padding{max-width:calc(1200px - 2rem)}@font-face{font-family:'dashing-icons';font-weight:normal;font-style:normal}.dashing-icon,i.dashing-tooltip,i.dashing-clippy,.app-menu .app-context .app-title .button--navigation{line-height:0}.dashing-icon:before,i.dashing-tooltip:before,i.dashing-clippy:before,.app-menu .app-context .app-title .button--navigation:before{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;color:#555;display:inline-block;font-family:"dashing-icons";font-size:16px;font-style:normal;font-weight:normal;line-height:1em;speak:none;text-decoration:inherit;text-align:center;opacity:.9;font-variant:normal;text-transform:none}.button .dashing-icon,.file-custom .file-custom--button .dashing-icon,button .dashing-icon,input[type='submit'] .dashing-icon,input[type='reset'] .dashing-icon,.app-menu .app-navigation li a .dashing-icon,.button i.dashing-tooltip,.file-custom .file-custom--button i.dashing-tooltip,button i.dashing-tooltip,input[type='submit'] i.dashing-tooltip,input[type='reset'] i.dashing-tooltip,.app-menu .app-navigation li a i.dashing-tooltip,.button i.dashing-clippy,.file-custom .file-custom--button i.dashing-clippy,button i.dashing-clippy,input[type='submit'] i.dashing-clippy,input[type='reset'] i.dashing-clippy,.app-menu .app-navigation li a i.dashing-clippy,.button .app-menu .app-context .app-title .button--navigation,.app-menu .app-context .app-title .button .button--navigation,.file-custom .file-custom--button .app-menu .app-context .app-title .button--navigation,.app-menu .app-context .app-title .file-custom .file-custom--button .button--navigation,button .app-menu .app-context .app-title .button--navigation,.app-menu .app-context .app-title button .button--navigation,input[type='submit'] .app-menu .app-context .app-title .button--navigation,.app-menu .app-context .app-title input[type='submit'] .button--navigation,input[type='reset'] .app-menu .app-context .app-title .button--navigation,.app-menu .app-context .app-title input[type='reset'] .button--navigation,.app-menu .app-navigation li a .app-context .app-title .button--navigation,.app-menu .app-context .app-title .app-navigation li a .button--navigation{display:inline-block;margin-right:0.2rem;margin-left:-0.2rem}.button .dashing-icon.flow-opposite,.file-custom .file-custom--button .dashing-icon.flow-opposite,button .dashing-icon.flow-opposite,input[type='submit'] .dashing-icon.flow-opposite,input[type='reset'] .dashing-icon.flow-opposite,.app-menu .app-navigation li a .dashing-icon.flow-opposite,.button i.flow-opposite.dashing-tooltip,.file-custom .file-custom--button i.flow-opposite.dashing-tooltip,button i.flow-opposite.dashing-tooltip,input[type='submit'] i.flow-opposite.dashing-tooltip,input[type='reset'] i.flow-opposite.dashing-tooltip,.app-menu .app-navigation li a i.flow-opposite.dashing-tooltip,.button i.flow-opposite.dashing-clippy,.file-custom .file-custom--button i.flow-opposite.dashing-clippy,button i.flow-opposite.dashing-clippy,input[type='submit'] i.flow-opposite.dashing-clippy,input[type='reset'] i.flow-opposite.dashing-clippy,.app-menu .app-navigation li a i.flow-opposite.dashing-clippy,.button .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title .button .flow-opposite.button--navigation,.file-custom .file-custom--button .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title .file-custom .file-custom--button .flow-opposite.button--navigation,button .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title button .flow-opposite.button--navigation,input[type='submit'] .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title input[type='submit'] .flow-opposite.button--navigation,input[type='reset'] .app-menu .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title input[type='reset'] .flow-opposite.button--navigation,.app-menu .app-navigation li a .app-context .app-title .flow-opposite.button--navigation,.app-menu .app-context .app-title .app-navigation li a .flow-opposite.button--navigation{margin-left:0.2rem;margin-right:-0.2rem}.button--icon .dashing-icon,.button--icon i.dashing-tooltip,.button--icon i.dashing-clippy,.button--icon .app-menu .app-context .app-title .button--navigation,.app-menu .app-context .app-title .button--icon .button--navigation{float:left;margin:0}.dashing-icon.dashing-icon--white:before,i.dashing-icon--white.dashing-tooltip:before,i.dashing-icon--white.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--white.button--navigation:before{color:#fff}.dashing-icon.dashing-icon--black:before,i.dashing-icon--black.dashing-tooltip:before,i.dashing-icon--black.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--black.button--navigation:before{color:#000}.dashing-icon.dashing-icon--blue:before,i.dashing-icon--blue.dashing-tooltip:before,i.dashing-icon--blue.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--blue.button--navigation:before{color:#5174BA}.dashing-icon.dashing-icon--gray:before,i.dashing-tooltip:before,i.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--gray.button--navigation:before,.app-menu .app-context .app-title i.button--navigation.dashing-tooltip:before,.app-menu .app-context .app-title i.button--navigation.dashing-clippy:before,.dashing-icon.dashing-icon--grey:before,i.dashing-icon--grey.dashing-tooltip:before,i.dashing-icon--grey.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--grey.button--navigation:before{color:#6E6E6E}.dashing-icon.dashing-icon--green:before,i.dashing-icon--green.dashing-tooltip:before,i.dashing-icon--green.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--green.button--navigation:before{color:#09AA66}.dashing-icon.dashing-icon--orange:before,i.dashing-icon--orange.dashing-tooltip:before,i.dashing-icon--orange.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--orange.button--navigation:before{color:#FFA11F}.dashing-icon.dashing-icon--red:before,i.dashing-icon--red.dashing-tooltip:before,i.dashing-icon--red.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--red.button--navigation:before{color:#DA3D30}.dashing-icon.dashing-icon--purple:before,i.dashing-icon--purple.dashing-tooltip:before,i.dashing-icon--purple.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--purple.button--navigation:before{color:#9F65AE}.dashing-icon.dashing-icon--ui-black:before,i.dashing-icon--ui-black.dashing-tooltip:before,i.dashing-icon--ui-black.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--ui-black.button--navigation:before{color:#40464C}.dashing-icon.dashing-icon--ui-blue:before,i.dashing-icon--ui-blue.dashing-tooltip:before,i.dashing-icon--ui-blue.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--ui-blue.button--navigation:before{color:#3F70C9}.dashing-icon.dashing-icon--ui-green:before,i.dashing-icon--ui-green.dashing-tooltip:before,i.dashing-icon--ui-green.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--ui-green.button--navigation:before{color:#09AA66}.dashing-icon.dashing-icon--ui-red:before,i.dashing-icon--ui-red.dashing-tooltip:before,i.dashing-icon--ui-red.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--ui-red.button--navigation:before{color:#DA3D30}.dashing-icon.dashing-icon--ui-orange:before,i.dashing-icon--ui-orange.dashing-tooltip:before,i.dashing-icon--ui-orange.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--ui-orange.button--navigation:before{color:#FFA11F}.dashing-icon.dashing-icon--brand-purple:before,i.dashing-icon--brand-purple.dashing-tooltip:before,i.dashing-icon--brand-purple.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--brand-purple.button--navigation:before{color:#9F65AE}.dashing-icon.dashing-icon--arrow-down:before,i.dashing-icon--arrow-down.dashing-tooltip:before,i.dashing-icon--arrow-down.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--arrow-down.button--navigation:before{content:'\e800'}.dashing-icon.dashing-icon--calendar:before,i.dashing-icon--calendar.dashing-tooltip:before,i.dashing-icon--calendar.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--calendar.button--navigation:before{content:'\e801'}.dashing-icon.dashing-icon--checkmark-filled:before,i.dashing-icon--checkmark-filled.dashing-tooltip:before,i.dashing-icon--checkmark-filled.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--checkmark-filled.button--navigation:before{content:'\e802'}.dashing-icon.dashing-icon--checkmark-stroke:before,i.dashing-icon--checkmark-stroke.dashing-tooltip:before,i.dashing-icon--checkmark-stroke.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--checkmark-stroke.button--navigation:before{content:'\e803'}.dashing-icon.dashing-icon--close:before,i.dashing-icon--close.dashing-tooltip:before,i.dashing-icon--close.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--close.button--navigation:before{content:'\e804'}.dashing-icon.dashing-icon--comment-add:before,i.dashing-icon--comment-add.dashing-tooltip:before,i.dashing-icon--comment-add.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--comment-add.button--navigation:before{content:'\e806'}.dashing-icon.dashing-icon--comment:before,i.dashing-icon--comment.dashing-tooltip:before,i.dashing-icon--comment.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--comment.button--navigation:before{content:'\e807'}.dashing-icon.dashing-icon--do-not-pull:before,i.dashing-icon--do-not-pull.dashing-tooltip:before,i.dashing-icon--do-not-pull.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--do-not-pull.button--navigation:before{content:'\e808'}.dashing-icon.dashing-icon--do-not-push:before,i.dashing-icon--do-not-push.dashing-tooltip:before,i.dashing-icon--do-not-push.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--do-not-push.button--navigation:before{content:'\e809'}.dashing-icon.dashing-icon--fit-page:before,i.dashing-icon--fit-page.dashing-tooltip:before,i.dashing-icon--fit-page.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--fit-page.button--navigation:before{content:'\e80a'}.dashing-icon.dashing-icon--fit-width:before,i.dashing-icon--fit-width.dashing-tooltip:before,i.dashing-icon--fit-width.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--fit-width.button--navigation:before{content:'\e80b'}.dashing-icon.dashing-icon--flip:before,i.dashing-icon--flip.dashing-tooltip:before,i.dashing-icon--flip.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--flip.button--navigation:before{content:'\e80c'}.dashing-icon.dashing-icon--hidden:before,i.dashing-icon--hidden.dashing-tooltip:before,i.dashing-icon--hidden.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--hidden.button--navigation:before{content:'\e80d'}.dashing-icon.dashing-icon--info:before,i.dashing-icon--info.dashing-tooltip:before,i.dashing-icon--info.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--info.button--navigation:before{content:'\e80e'}.dashing-icon.dashing-icon--info-filled:before,i.dashing-icon--info-filled.dashing-tooltip:before,i.dashing-icon--info-filled.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--info-filled.button--navigation:before{content:'\e80f'}.dashing-icon.dashing-icon--info-stroke:before,i.dashing-icon--info-stroke.dashing-tooltip:before,i.dashing-icon--info-stroke.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--info-stroke.button--navigation:before{content:'\e810'}.dashing-icon.dashing-icon--location:before,i.dashing-icon--location.dashing-tooltip:before,i.dashing-icon--location.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--location.button--navigation:before{content:'\e811'}.dashing-icon.dashing-icon--locked:before,i.dashing-icon--locked.dashing-tooltip:before,i.dashing-icon--locked.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--locked.button--navigation:before{content:'\e812'}.dashing-icon.dashing-icon--minus:before,i.dashing-icon--minus.dashing-tooltip:before,i.dashing-icon--minus.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--minus.button--navigation:before,.dashing-icon.dashing-icon--zoom-out:before,i.dashing-icon--zoom-out.dashing-tooltip:before,i.dashing-icon--zoom-out.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--zoom-out.button--navigation:before{content:'\e814'}.dashing-icon.dashing-icon--new-tab:before,i.dashing-icon--new-tab.dashing-tooltip:before,i.dashing-icon--new-tab.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--new-tab.button--navigation:before{content:'\e815'}.dashing-icon.dashing-icon--notification:before,i.dashing-icon--notification.dashing-tooltip:before,i.dashing-icon--notification.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--notification.button--navigation:before{content:'\e816'}.dashing-icon.dashing-icon--page:before,i.dashing-icon--page.dashing-tooltip:before,i.dashing-icon--page.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--page.button--navigation:before{content:'\e817'}.dashing-icon.dashing-icon--pencil:before,i.dashing-icon--pencil.dashing-tooltip:before,i.dashing-icon--pencil.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--pencil.button--navigation:before{content:'\e818'}.dashing-icon.dashing-icon--phone:before,i.dashing-icon--phone.dashing-tooltip:before,i.dashing-icon--phone.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--phone.button--navigation:before{content:'\e819'}.dashing-icon.dashing-icon--play:before,i.dashing-icon--play.dashing-tooltip:before,i.dashing-icon--play.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--play.button--navigation:before{content:'\e81b'}.dashing-icon.dashing-icon--plus:before,i.dashing-icon--plus.dashing-tooltip:before,i.dashing-icon--plus.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--plus.button--navigation:before,.dashing-icon.dashing-icon--add:before,i.dashing-icon--add.dashing-tooltip:before,i.dashing-icon--add.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--add.button--navigation:before,.dashing-icon.dashing-icon--zoom-in:before,i.dashing-icon--zoom-in.dashing-tooltip:before,i.dashing-icon--zoom-in.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--zoom-in.button--navigation:before{content:'\e81c'}.dashing-icon.dashing-icon--pull:before,i.dashing-icon--pull.dashing-tooltip:before,i.dashing-icon--pull.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--pull.button--navigation:before{content:'\e81d'}.dashing-icon.dashing-icon--push:before,i.dashing-icon--push.dashing-tooltip:before,i.dashing-icon--push.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--push.button--navigation:before{content:'\e81e'}.dashing-icon.dashing-icon--question-filled:before,i.dashing-tooltip:before,i.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--question-filled.button--navigation:before,.app-menu .app-context .app-title i.button--navigation.dashing-tooltip:before,.app-menu .app-context .app-title i.button--navigation.dashing-clippy:before{content:'\e81f'}.dashing-icon.dashing-icon--quicknav:before,i.dashing-icon--quicknav.dashing-tooltip:before,i.dashing-icon--quicknav.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--quicknav.button--navigation:before,.dashing-icon.dashing-icon--grid:before,i.dashing-icon--grid.dashing-tooltip:before,i.dashing-icon--grid.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--grid.button--navigation:before{content:'\e820'}.dashing-icon.dashing-icon--reply:before,i.dashing-icon--reply.dashing-tooltip:before,i.dashing-icon--reply.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--reply.button--navigation:before{content:'\e821'}.dashing-icon.dashing-icon--rotate:before,i.dashing-icon--rotate.dashing-tooltip:before,i.dashing-icon--rotate.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--rotate.button--navigation:before{content:'\e822'}.dashing-icon.dashing-icon--search:before,i.dashing-icon--search.dashing-tooltip:before,i.dashing-icon--search.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--search.button--navigation:before{content:'\e823'}.dashing-icon.dashing-icon--settings:before,i.dashing-icon--settings.dashing-tooltip:before,i.dashing-icon--settings.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--settings.button--navigation:before{content:'\e824'}.dashing-icon.dashing-icon--show:before,i.dashing-icon--show.dashing-tooltip:before,i.dashing-icon--show.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--show.button--navigation:before{content:'\e825'}.dashing-icon.dashing-icon--time:before,i.dashing-icon--time.dashing-tooltip:before,i.dashing-icon--time.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--time.button--navigation:before{content:'\e826'}.dashing-icon.dashing-icon--trash:before,i.dashing-icon--trash.dashing-tooltip:before,i.dashing-icon--trash.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--trash.button--navigation:before{content:'\e827'}.dashing-icon.dashing-icon--unlocked:before,i.dashing-icon--unlocked.dashing-tooltip:before,i.dashing-icon--unlocked.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--unlocked.button--navigation:before{content:'\e828'}.dashing-icon.dashing-icon--view-double:before,i.dashing-icon--view-double.dashing-tooltip:before,i.dashing-icon--view-double.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--view-double.button--navigation:before{content:'\e829'}.dashing-icon.dashing-icon--arrow-left:before,i.dashing-icon--arrow-left.dashing-tooltip:before,i.dashing-icon--arrow-left.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--arrow-left.button--navigation:before{content:'\e82a'}.dashing-icon.dashing-icon--arrow-long-down:before,i.dashing-icon--arrow-long-down.dashing-tooltip:before,i.dashing-icon--arrow-long-down.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--arrow-long-down.button--navigation:before{content:'\e82b'}.dashing-icon.dashing-icon--arrow-long-left:before,i.dashing-icon--arrow-long-left.dashing-tooltip:before,i.dashing-icon--arrow-long-left.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--arrow-long-left.button--navigation:before{content:'\e82c'}.dashing-icon.dashing-icon--arrow-long-up:before,i.dashing-icon--arrow-long-up.dashing-tooltip:before,i.dashing-icon--arrow-long-up.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--arrow-long-up.button--navigation:before{content:'\e82d'}.dashing-icon.dashing-icon--arrow-right:before,i.dashing-icon--arrow-right.dashing-tooltip:before,i.dashing-icon--arrow-right.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--arrow-right.button--navigation:before{content:'\e82e'}.dashing-icon.dashing-icon--arrow-up:before,i.dashing-icon--arrow-up.dashing-tooltip:before,i.dashing-icon--arrow-up.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--arrow-up.button--navigation:before{content:'\e82f'}.dashing-icon.dashing-icon--heart:before,i.dashing-icon--heart.dashing-tooltip:before,i.dashing-icon--heart.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--heart.button--navigation:before{content:'\e832'}.dashing-icon.dashing-icon--question-stroke:before,i.dashing-icon--question-stroke.dashing-tooltip:before,i.dashing-icon--question-stroke.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--question-stroke.button--navigation:before{content:'\e833'}.dashing-icon.dashing-icon--view-single:before,i.dashing-icon--view-single.dashing-tooltip:before,i.dashing-icon--view-single.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--view-single.button--navigation:before{content:'\e834'}.dashing-icon.dashing-icon--checkmark:before,i.dashing-icon--checkmark.dashing-tooltip:before,i.dashing-icon--checkmark.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--checkmark.button--navigation:before{content:'\e835'}.dashing-icon.dashing-icon--arrow-long-right:before,i.dashing-icon--arrow-long-right.dashing-tooltip:before,i.dashing-icon--arrow-long-right.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--arrow-long-right.button--navigation:before{content:'\e836'}.dashing-icon.dashing-icon--alert-stroke:before,i.dashing-icon--alert-stroke.dashing-tooltip:before,i.dashing-icon--alert-stroke.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--alert-stroke.button--navigation:before{content:'\e837'}.dashing-icon.dashing-icon--alert-filled:before,i.dashing-icon--alert-filled.dashing-tooltip:before,i.dashing-icon--alert-filled.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--alert-filled.button--navigation:before{content:'\e838'}.dashing-icon.dashing-icon--add-person:before,i.dashing-icon--add-person.dashing-tooltip:before,i.dashing-icon--add-person.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--add-person.button--navigation:before{content:'\e839'}.dashing-icon.dashing-icon--inbox:before,i.dashing-icon--inbox.dashing-tooltip:before,i.dashing-icon--inbox.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--inbox.button--navigation:before{content:'\e83d'}.dashing-icon.dashing-icon--face-amazing:before,i.dashing-icon--face-amazing.dashing-tooltip:before,i.dashing-icon--face-amazing.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--face-amazing.button--navigation:before{content:'\e83e'}.dashing-icon.dashing-icon--face-awful:before,i.dashing-icon--face-awful.dashing-tooltip:before,i.dashing-icon--face-awful.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--face-awful.button--navigation:before{content:'\e83f'}.dashing-icon.dashing-icon--face-ok:before,i.dashing-icon--face-ok.dashing-tooltip:before,i.dashing-icon--face-ok.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--face-ok.button--navigation:before{content:'\e840'}.dashing-icon.dashing-icon--face-good:before,i.dashing-icon--face-good.dashing-tooltip:before,i.dashing-icon--face-good.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--face-good.button--navigation:before{content:'\e841'}.dashing-icon.dashing-icon--face-bad:before,i.dashing-icon--face-bad.dashing-tooltip:before,i.dashing-icon--face-bad.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--face-bad.button--navigation:before{content:'\e842'}.dashing-icon.dashing-icon--mobile-phone:before,i.dashing-icon--mobile-phone.dashing-tooltip:before,i.dashing-icon--mobile-phone.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--mobile-phone.button--navigation:before{content:'\e844'}.dashing-icon.dashing-icon--notification-off:before,i.dashing-icon--notification-off.dashing-tooltip:before,i.dashing-icon--notification-off.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--notification-off.button--navigation:before{content:'\e845'}.dashing-icon.dashing-icon--star-stroke:before,i.dashing-icon--star-stroke.dashing-tooltip:before,i.dashing-icon--star-stroke.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--star-stroke.button--navigation:before{content:'\e847'}.dashing-icon.dashing-icon--star-filled:before,i.dashing-icon--star-filled.dashing-tooltip:before,i.dashing-icon--star-filled.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--star-filled.button--navigation:before,.dashing-icon.dashing-icon--star:before,i.dashing-icon--star.dashing-tooltip:before,i.dashing-icon--star.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--star.button--navigation:before{content:'\e831'}.dashing-icon.dashing-icon--menu:before,i.dashing-icon--menu.dashing-tooltip:before,i.dashing-icon--menu.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--menu.button--navigation:before{content:'\e849'}.dashing-icon.dashing-icon--categories:before,i.dashing-icon--categories.dashing-tooltip:before,i.dashing-icon--categories.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--categories.button--navigation:before{content:'\e84a'}.dashing-icon.dashing-icon--mail:before,i.dashing-icon--mail.dashing-tooltip:before,i.dashing-icon--mail.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--mail.button--navigation:before{content:'\e81a'}.dashing-icon.dashing-icon--chat-filled:before,i.dashing-icon--chat-filled.dashing-tooltip:before,i.dashing-icon--chat-filled.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--chat-filled.button--navigation:before{content:'\e813'}.dashing-icon.dashing-icon--popular:before,i.dashing-icon--popular.dashing-tooltip:before,i.dashing-icon--popular.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--popular.button--navigation:before{content:'\e830'}.dashing-icon.dashing-icon--paper-check:before,i.dashing-icon--paper-check.dashing-tooltip:before,i.dashing-icon--paper-check.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--paper-check.button--navigation:before{content:'\e83a'}.dashing-icon.dashing-icon--paper-check-2:before,i.dashing-icon--paper-check-2.dashing-tooltip:before,i.dashing-icon--paper-check-2.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--paper-check-2.button--navigation:before{content:'\e805'}.dashing-icon.dashing-icon--pause:before,i.dashing-icon--pause.dashing-tooltip:before,i.dashing-icon--pause.dashing-clippy:before,.app-menu .app-context .app-title .dashing-icon--pause.button--navigation:before{content:'\e846'}.dash-spinner,.has-spinner:after,.button.has-spinner:after,.file-custom .has-spinner.file-custom--button:after{-webkit-animation:rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);-moz-animation:rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);-ms-animation:rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);-o-animation:rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);animation:rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);position:relative;border-radius:100%;border:6px solid rgba(0,0,0,0.15);border-top:6px solid #000;float:left;height:90px;width:90px;top:calc(50% - (90px/2));left:calc(50% - (90px/2))}.dash-spinner.small,.small.has-spinner:after{border-width:3px;height:32px;width:32px;top:calc(50% - (32px/2));left:calc(50% - (32px/2))}.has-spinner{background-color:#f2f2f2;position:fixed;top:0;bottom:0;left:0;right:0;z-index:10}.has-spinner:after{content:"";position:absolute}.button.has-spinner,.file-custom .has-spinner.file-custom--button{pointer-events:none;color:transparent;position:relative}.button.has-spinner:hover,.file-custom .has-spinner.file-custom--button:hover,.button.has-spinner:active,.file-custom .has-spinner.file-custom--button:active,.button.has-spinner:focus,.file-custom .has-spinner.file-custom--button:focus{color:transparent}.button.has-spinner:after,.file-custom .has-spinner.file-custom--button:after{content:"";border-width:3px;border-color:rgba(255,255,255,0.15);border-top-color:#fff;position:absolute;height:24px;width:24px;top:calc(50% - (24px/2));left:calc(50% - (24px/2))}@-webkit-keyframes rotation{from{-webkit-transform:rotate(0deg)}to{-webkit-transform:rotate(359deg)}}@-moz-keyframes rotation{from{-moz-transform:rotate(0deg)}to{-moz-transform:rotate(359deg)}}@-o-keyframes rotation{from{-o-transform:rotate(0deg)}to{-o-transform:rotate(359deg)}}@keyframes rotation{from{transform:rotate(0deg)}to{transform:rotate(359deg)}}.tag{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;background-color:#E0E0E0;border-radius:3px;border:2px solid #E0E0E0;color:#3F70C9;cursor:pointer;display:inline-block;font-size:.8rem;font-weight:600;min-width:1rem;padding:0.1rem 0.25rem;text-transform:uppercase;margin:0.25rem}.tag:not(.tag--no-link):hover,.tag:not(.tag--no-link):focus{border:2px solid #3F70C9;color:#3F70C9;transition:border-color .1s ease-in-out}.tag.tag--no-link{opacity:1;cursor:initial}.tag.tag--large{font-size:1rem}.tag.tag--primary,.tag.tag--blue{background-color:#E0E0E0;border-color:#E0E0E0;color:#3F70C9}.tag.tag--primary:not(.tag--no-link):hover,.tag.tag--primary:not(.tag--no-link):focus,.tag.tag--blue:not(.tag--no-link):hover,.tag.tag--blue:not(.tag--no-link):focus{border-color:#3F70C9;color:#678ed4}.tag.tag--secondary,.tag.tag--gray,.tag.tag--grey{background-color:#E0E0E0;border-color:#E0E0E0;color:#3B3B3B}.tag.tag--secondary:not(.tag--no-link):hover,.tag.tag--secondary:not(.tag--no-link):focus,.tag.tag--gray:not(.tag--no-link):hover,.tag.tag--gray:not(.tag--no-link):focus,.tag.tag--grey:not(.tag--no-link):hover,.tag.tag--grey:not(.tag--no-link):focus{border-color:#3B3B3B;color:#555}.tag.tag--green{background-color:#E0E0E0;border-color:#E0E0E0;color:#149853}.tag.tag--green:not(.tag--no-link):hover,.tag.tag--green:not(.tag--no-link):focus{border-color:#149853;color:#1ac56c}.tag.tag--orange{background-color:#E0E0E0;border-color:#E0E0E0;color:#C47A18}.tag.tag--orange:not(.tag--no-link):hover,.tag.tag--orange:not(.tag--no-link):focus{border-color:#C47A18;color:#e5952a}.tag.tag--purple{background-color:#E0E0E0;border-color:#E0E0E0;color:#9F65AE}.tag.tag--purple:not(.tag--no-link):hover,.tag.tag--purple:not(.tag--no-link):focus{border-color:#9F65AE;color:#b486c0}.tag.tag--red{background-color:#E0E0E0;border-color:#E0E0E0;color:#DA3D30}.tag.tag--red:not(.tag--no-link):hover,.tag.tag--red:not(.tag--no-link):focus{border-color:#DA3D30;color:#e2665b}.tag.tag--white{background-color:#E0E0E0;border-color:#E0E0E0;color:#fff}.tag.tag--white:not(.tag--no-link):hover,.tag.tag--white:not(.tag--no-link):focus{border-color:#fff;color:#fff}.tag.tag--black{background-color:#E0E0E0;border-color:#E0E0E0;color:#40464C}.tag.tag--black:not(.tag--no-link):hover,.tag.tag--black:not(.tag--no-link):focus{border-color:#40464C;color:#576068}.tag--solid.tag--primary,.tag--solid.tag--blue{background-color:#3F70C9;border-color:#3F70C9;color:#fff}.tag--solid.tag--primary:not(.tag--no-link):hover,.tag--solid.tag--primary:not(.tag--no-link):focus,.tag--solid.tag--blue:not(.tag--no-link):hover,.tag--solid.tag--blue:not(.tag--no-link):focus{border-color:#24447e;color:#fff}.tag--solid.tag--secondary,.tag--solid.tag--grey,.tag--solid.tag--gray{background-color:#D4D4D4;border-color:#D4D4D4;color:#24292C}.tag--solid.tag--secondary:not(.tag--no-link):hover,.tag--solid.tag--secondary:not(.tag--no-link):focus,.tag--solid.tag--grey:not(.tag--no-link):hover,.tag--solid.tag--grey:not(.tag--no-link):focus,.tag--solid.tag--gray:not(.tag--no-link):hover,.tag--solid.tag--gray:not(.tag--no-link):focus{border-color:#a1a1a1;color:#3b4348}.tag--solid.tag--green{background-color:#09AA66;border-color:#09AA66;color:#fff}.tag--solid.tag--green:not(.tag--no-link):hover,.tag--solid.tag--green:not(.tag--no-link):focus{border-color:#04492c;color:#fff}.tag--solid.tag--orange{background-color:#FFA11F;border-color:#FFA11F;color:#24292C}.tag--solid.tag--orange:not(.tag--no-link):hover,.tag--solid.tag--orange:not(.tag--no-link):focus{border-color:#b86b00;color:#3b4348}.tag--solid.tag--purple{background-color:#9F65AE;border-color:#9F65AE;color:#fff}.tag--solid.tag--purple:not(.tag--no-link):hover,.tag--solid.tag--purple:not(.tag--no-link):focus{border-color:#663c71;color:#fff}.tag--solid.tag--red{background-color:#DA3D30;border-color:#DA3D30;color:#fff}.tag--solid.tag--red:not(.tag--no-link):hover,.tag--solid.tag--red:not(.tag--no-link):focus{border-color:#8b2219;color:#fff}.tag--solid.tag--white{background-color:#fff;border-color:#fff;color:#24292C}.tag--solid.tag--white:not(.tag--no-link):hover,.tag--solid.tag--white:not(.tag--no-link):focus{border-color:#ccc;color:#3b4348}.tag--counter{display:inline-block;background-color:transparent}.tag--counter.tag--no-link{opacity:1;cursor:initial}.tag--counter:not(.tag--no-link):hover .tag,.tag--counter:not(.tag--no-link):focus .tag{border-color:#3F70C9;transition:border-color .1s ease-in-out}.tag--counter:not(.tag--no-link):hover .tag.tag--primary,.tag--counter:not(.tag--no-link):hover .tag.tag--blue,.tag--counter:not(.tag--no-link):focus .tag.tag--primary,.tag--counter:not(.tag--no-link):focus .tag.tag--blue{border-color:#24447e}.tag--counter:not(.tag--no-link):hover .tag.tag--secondary,.tag--counter:not(.tag--no-link):hover .tag.tag--grey,.tag--counter:not(.tag--no-link):hover .tag.tag--gray,.tag--counter:not(.tag--no-link):focus .tag.tag--secondary,.tag--counter:not(.tag--no-link):focus .tag.tag--grey,.tag--counter:not(.tag--no-link):focus .tag.tag--gray{border-color:#a1a1a1}.tag--counter:not(.tag--no-link):hover .tag.tag--green,.tag--counter:not(.tag--no-link):focus .tag.tag--green{border-color:#04492c}.tag--counter:not(.tag--no-link):hover .tag.tag--orange,.tag--counter:not(.tag--no-link):focus .tag.tag--orange{border-color:#b86b00}.tag--counter:not(.tag--no-link):hover .tag.tag--purple,.tag--counter:not(.tag--no-link):focus .tag.tag--purple{border-color:#663c71}.tag--counter:not(.tag--no-link):hover .tag.tag--red,.tag--counter:not(.tag--no-link):focus .tag.tag--red{border-color:#8b2219}.tag--counter:not(.tag--no-link):hover .tag.tag--white,.tag--counter:not(.tag--no-link):focus .tag.tag--white{border-color:#ccc}.tag--counter .tag:first-child{border-radius:3px 0 0 3px;border-right:transparent;margin-right:0}.tag--counter .tag:last-child{border-radius:0 3px 3px 0;background-color:#fff;color:#3B3B3B;border-left:transparent;margin-left:0}.tag--counter .tag:last-child:not(.tag--no-link):hover,.tag--counter .tag:last-child:not(.tag--no-link):focus{color:#3B3B3B}.tag.plan-11{background-color:#FFA11F;border-color:#FFA11F;color:#000}.tag.plan-11:not(.tag--no-link):hover,.tag.plan-11:not(.tag--no-link):focus{border-color:#b86b00;color:#1a1a1a}.tag--counter:not(.tag--no-link):hover .tag.plan-11,.tag--counter:not(.tag--no-link):focus .tag.plan-11{border-color:#b86b00}.plan-1.tag{background-color:#8560A8;border-color:#8560A8;color:#fff}.plan-1.tag:not(.tag--no-link):hover,.plan-1.tag:not(.tag--no-link):focus{border-color:#523969;color:#fff}.tag--counter:not(.tag--no-link):hover .tag.plan-1,.tag--counter:not(.tag--no-link):focus .tag.plan-1{border-color:#523969}.plan-0.tag{background-color:#09AA66;border-color:#09AA66;color:#fff}.plan-0.tag:not(.tag--no-link):hover,.plan-0.tag:not(.tag--no-link):focus{border-color:#04492c;color:#fff}.tag--counter:not(.tag--no-link):hover .tag.plan-0,.tag--counter:not(.tag--no-link):focus .tag.plan-0{border-color:#04492c}.progress-container{margin:auto;max-width:750px;padding:2rem 1rem}.progress{background-color:#E0E0E0;border-radius:15px;height:15px;width:100%;overflow:hidden}.progress .progress-bar{border-radius:15px;height:100%;background-color:#09AA66}.progress-labels{display:flex}.progress-label,.progress-label a{color:#6E6E6E;display:flex;padding:0;padding-top:0.5rem;flex-grow:1;font-size:0.8rem;font-weight:600;justify-content:center;text-align:center}@media all and (min-width: 40em){.progress-label,.progress-label a{font-size:0.9rem}}.progress-label.progress-label--completed,.progress-label.progress-label--completed a,.progress-label a.progress-label--completed,.progress-label a.progress-label--completed a{color:#09AA66}.progress-bar--1of2{width:calc(1/4 * 100%)}.progress-bar--2of2{width:calc(3/4 * 100%)}.progress-bar--1of3{width:calc(1/6 * 100%)}.progress-bar--2of3{width:calc(3/6 * 100%)}.progress-bar--3of3{width:calc(5/6 * 100%)}.progress-bar--1of4{width:calc(1/8 * 100%)}.progress-bar--2of4{width:calc(3/8 * 100%)}.progress-bar--3of4{width:calc(5/8 * 100%)}.progress-bar--4of4{width:calc(7/8 * 100%)}.progress-bar--completed{width:100%}.ordered-list--custom{margin:0;padding:0;list-style-type:none;counter-reset:step-counter}.ordered-list--custom li{counter-increment:step-counter;margin-bottom:1rem;display:flex;align-items:baseline}.ordered-list--custom li::before{content:counter(step-counter);margin-right:.5rem;font-size:1rem;background-color:#D4D4D4;color:#000;font-weight:600;padding:.3rem .7rem;border-radius:50%}.ordered-list--custom li:last-of-type{margin-bottom:0}.ordered-list--custom>*:not(li){text-indent:2.5rem}.ordered-list--custom.ordered-list--sharing-blue li::before{background-color:#71B9E0;color:#fff}
+@charset "UTF-8";
+/* ==========================================================================
+   Normalize.scss settings
+   ========================================================================== */
+/**
+ * Includes legacy browser support IE6/7
+ *
+ * Set to false if you want to drop support for IE6 and IE7
+ */
+/* Base
+   ========================================================================== */
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
+ * 3. Corrects text resizing oddly in IE 6/7 when body `font-size` is set using
+ *  `em` units.
+ */
+@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600);
+html {
+  font-family: sans-serif;
+  /* 1 */
+  -ms-text-size-adjust: 100%;
+  /* 2 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */ }
+
+/**
+ * Remove default margin.
+ */
+body {
+  margin: 0; }
+
+/* HTML5 display definitions
+   ========================================================================== */
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block; }
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 6/7/8/9 and Firefox 3.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+  /* 1 */
+  vertical-align: baseline;
+  /* 2 */ }
+
+/**
+ * Prevents modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+audio:not([controls]) {
+  display: none;
+  height: 0; }
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+[hidden],
+template {
+  display: none; }
+
+/* Links
+   ========================================================================== */
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+a {
+  background-color: transparent; }
+
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+a:active, a:hover {
+  outline: 0; }
+
+/* Text-level semantics
+   ========================================================================== */
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+abbr[title] {
+  border-bottom: 1px dotted; }
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+b,
+strong {
+  font-weight: bold; }
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+dfn {
+  font-style: italic; }
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0; }
+
+/**
+ * Addresses styling not present in IE 8/9.
+ */
+mark {
+  background: #ff0;
+  color: #000; }
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+small {
+  font-size: 80%; }
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline; }
+
+sup {
+  top: -0.5em; }
+
+sub {
+  bottom: -0.25em; }
+
+/* Embedded content
+   ========================================================================== */
+/**
+ * 1. Remove border when inside `a` element in IE 8/9/10.
+ * 2. Improves image quality when scaled in IE 7.
+ */
+img {
+  border: 0; }
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+svg:not(:root) {
+  overflow: hidden; }
+
+/* Grouping content
+   ========================================================================== */
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+figure {
+  margin: 1em 40px; }
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+hr {
+  box-sizing: content-box;
+  height: 0; }
+
+/**
+ * Contain overflow in all browsers.
+ */
+pre {
+  overflow: auto; }
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ * Correct font family set oddly in IE 6, Safari 4/5, and Chrome.
+ */
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em; }
+
+/* Forms
+   ========================================================================== */
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+/**
+ * 1. Correct color not being inherited.
+ *  Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ * 4. Improves appearance and consistency in all browsers.
+ */
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+  margin: 0;
+  /* 3 */ }
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+button {
+  overflow: visible; }
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+button,
+select {
+  text-transform: none; }
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *  and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *  `input` and others.
+ * 4. Removes inner spacing in IE 7 without affecting normal text inputs.
+ *  Known issue: inner spacing remains in IE 6.
+ */
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  /* 2 */
+  cursor: pointer;
+  /* 3 */ }
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+button[disabled],
+html input[disabled] {
+  cursor: default; }
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0; }
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+input {
+  line-height: normal; }
+
+/**
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ *  Known issue: excess padding remains in IE 6.
+ */
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box;
+  /* 1 */
+  padding: 0;
+  /* 2 */ }
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto; }
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ */
+input[type="search"] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  box-sizing: content-box;
+  /* 2 */ }
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none; }
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em; }
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ * 3. Corrects text not wrapping in Firefox 3.
+ * 4. Corrects alignment displayed oddly in IE 6/7.
+ */
+legend {
+  border: 0;
+  /* 1 */
+  padding: 0;
+  /* 2 */ }
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+textarea {
+  overflow: auto; }
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+optgroup {
+  font-weight: bold; }
+
+/* Tables
+   ========================================================================== */
+/**
+ * Remove most spacing between table cells.
+ */
+table {
+  border-collapse: collapse;
+  border-spacing: 0; }
+
+td,
+th {
+  padding: 0; }
+
+/* This is the core CSS of Tooltipster */
+/* GENERAL STRUCTURE RULES (do not edit this section) */
+.tooltipster-base {
+  /* this ensures that a constrained height set by functionPosition,
+  if greater that the natural height of the tooltip, will be enforced
+  in browsers that support display:flex */
+  display: flex;
+  pointer-events: none;
+  /* this may be overriden in JS for fixed position origins */
+  position: absolute; }
+
+.tooltipster-box {
+  /* see .tooltipster-base. flex-shrink 1 is only necessary for IE10-
+  and flex-basis auto for IE11- (at least) */
+  flex: 1 1 auto; }
+
+.tooltipster-content {
+  /* prevents an overflow if the user adds padding to the div */
+  box-sizing: border-box;
+  /* these make sure we'll be able to detect any overflow */
+  max-height: 100%;
+  max-width: 100%;
+  overflow: auto; }
+
+.tooltipster-ruler {
+  /* these let us test the size of the tooltip without overflowing the window */
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  position: fixed;
+  right: 0;
+  top: 0;
+  visibility: hidden; }
+
+/* ANIMATIONS */
+/* Open/close animations */
+/* fade */
+.tooltipster-fade {
+  opacity: 0;
+  -webkit-transition-property: opacity;
+  -moz-transition-property: opacity;
+  -o-transition-property: opacity;
+  -ms-transition-property: opacity;
+  transition-property: opacity; }
+
+.tooltipster-fade.tooltipster-show {
+  opacity: 1; }
+
+/* grow */
+.tooltipster-grow {
+  -webkit-transform: scale(0, 0);
+  -moz-transform: scale(0, 0);
+  -o-transform: scale(0, 0);
+  -ms-transform: scale(0, 0);
+  transform: scale(0, 0);
+  -webkit-transition-property: -webkit-transform;
+  -moz-transition-property: -moz-transform;
+  -o-transition-property: -o-transform;
+  -ms-transition-property: -ms-transform;
+  transition-property: transform;
+  -webkit-backface-visibility: hidden; }
+
+.tooltipster-grow.tooltipster-show {
+  -webkit-transform: scale(1, 1);
+  -moz-transform: scale(1, 1);
+  -o-transform: scale(1, 1);
+  -ms-transform: scale(1, 1);
+  transform: scale(1, 1);
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  -moz-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  -ms-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  -o-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15); }
+
+/* swing */
+.tooltipster-swing {
+  opacity: 0;
+  -webkit-transform: rotateZ(4deg);
+  -moz-transform: rotateZ(4deg);
+  -o-transform: rotateZ(4deg);
+  -ms-transform: rotateZ(4deg);
+  transform: rotateZ(4deg);
+  -webkit-transition-property: -webkit-transform, opacity;
+  -moz-transition-property: -moz-transform;
+  -o-transition-property: -o-transform;
+  -ms-transition-property: -ms-transform;
+  transition-property: transform; }
+
+.tooltipster-swing.tooltipster-show {
+  opacity: 1;
+  -webkit-transform: rotateZ(0deg);
+  -moz-transform: rotateZ(0deg);
+  -o-transform: rotateZ(0deg);
+  -ms-transform: rotateZ(0deg);
+  transform: rotateZ(0deg);
+  -webkit-transition-timing-function: cubic-bezier(0.23, 0.635, 0.495, 1);
+  -webkit-transition-timing-function: cubic-bezier(0.23, 0.635, 0.495, 2.4);
+  -moz-transition-timing-function: cubic-bezier(0.23, 0.635, 0.495, 2.4);
+  -ms-transition-timing-function: cubic-bezier(0.23, 0.635, 0.495, 2.4);
+  -o-transition-timing-function: cubic-bezier(0.23, 0.635, 0.495, 2.4);
+  transition-timing-function: cubic-bezier(0.23, 0.635, 0.495, 2.4); }
+
+/* fall */
+.tooltipster-fall {
+  -webkit-transition-property: top;
+  -moz-transition-property: top;
+  -o-transition-property: top;
+  -ms-transition-property: top;
+  transition-property: top;
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  -moz-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  -ms-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  -o-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15); }
+
+.tooltipster-fall.tooltipster-initial {
+  top: 0 !important; }
+
+.tooltipster-fall.tooltipster-dying {
+  -webkit-transition-property: all;
+  -moz-transition-property: all;
+  -o-transition-property: all;
+  -ms-transition-property: all;
+  transition-property: all;
+  top: 0 !important;
+  opacity: 0; }
+
+/* slide */
+.tooltipster-slide {
+  -webkit-transition-property: left;
+  -moz-transition-property: left;
+  -o-transition-property: left;
+  -ms-transition-property: left;
+  transition-property: left;
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
+  -webkit-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  -moz-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  -ms-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  -o-transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15);
+  transition-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.15); }
+
+.tooltipster-slide.tooltipster-initial {
+  left: -40px !important; }
+
+.tooltipster-slide.tooltipster-dying {
+  -webkit-transition-property: all;
+  -moz-transition-property: all;
+  -o-transition-property: all;
+  -ms-transition-property: all;
+  transition-property: all;
+  left: 0 !important;
+  opacity: 0; }
+
+/* Update animations */
+/* We use animations rather than transitions here because
+ transition durations may be specified in the style tag due to
+ animationDuration, and we try to avoid collisions and the use
+ of !important */
+/* fade */
+@keyframes tooltipster-fading {
+  0% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
+.tooltipster-update-fade {
+  animation: tooltipster-fading 400ms; }
+
+/* rotate */
+@keyframes tooltipster-rotating {
+  25% {
+    transform: rotate(-2deg); }
+  75% {
+    transform: rotate(2deg); }
+  100% {
+    transform: rotate(0); } }
+.tooltipster-update-rotate {
+  animation: tooltipster-rotating 600ms; }
+
+/* scale */
+@keyframes tooltipster-scaling {
+  50% {
+    transform: scale(1.1); }
+  100% {
+    transform: scale(1); } }
+.tooltipster-update-scale {
+  animation: tooltipster-scaling 600ms; }
+
+/**
+ * DEFAULT STYLE OF THE SIDETIP PLUGIN
+ *
+ * All styles are "namespaced" with .tooltipster-sidetip to prevent
+ * conflicts between plugins.
+ */
+/* .tooltipster-box */
+.tooltipster-sidetip .tooltipster-box {
+  background: #565656;
+  border: 2px solid black;
+  border-radius: 4px; }
+
+.tooltipster-sidetip.tooltipster-bottom .tooltipster-box {
+  margin-top: 8px; }
+
+.tooltipster-sidetip.tooltipster-left .tooltipster-box {
+  margin-right: 8px; }
+
+.tooltipster-sidetip.tooltipster-right .tooltipster-box {
+  margin-left: 8px; }
+
+.tooltipster-sidetip.tooltipster-top .tooltipster-box {
+  margin-bottom: 8px; }
+
+/* .tooltipster-content */
+.tooltipster-sidetip .tooltipster-content {
+  color: white;
+  line-height: 18px;
+  padding: 6px 14px; }
+
+/* .tooltipster-arrow : will keep only the zone of .tooltipster-arrow-uncropped that
+corresponds to the arrow we want to display */
+.tooltipster-sidetip .tooltipster-arrow {
+  overflow: hidden;
+  position: absolute; }
+
+.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow {
+  height: 10px;
+  /* half the width, for centering */
+  margin-left: -10px;
+  top: 0;
+  width: 20px; }
+
+.tooltipster-sidetip.tooltipster-left .tooltipster-arrow {
+  height: 20px;
+  margin-top: -10px;
+  right: 0;
+  /* top 0 to keep the arrow from overflowing .tooltipster-base when it has not
+  been positioned yet */
+  top: 0;
+  width: 10px; }
+
+.tooltipster-sidetip.tooltipster-right .tooltipster-arrow {
+  height: 20px;
+  margin-top: -10px;
+  left: 0;
+  /* same as .tooltipster-left .tooltipster-arrow */
+  top: 0;
+  width: 10px; }
+
+.tooltipster-sidetip.tooltipster-top .tooltipster-arrow {
+  bottom: 0;
+  height: 10px;
+  margin-left: -10px;
+  width: 20px; }
+
+/* common rules between .tooltipster-arrow-background and .tooltipster-arrow-border */
+.tooltipster-sidetip .tooltipster-arrow-background, .tooltipster-sidetip .tooltipster-arrow-border {
+  height: 0;
+  position: absolute;
+  width: 0; }
+
+/* .tooltipster-arrow-background */
+.tooltipster-sidetip .tooltipster-arrow-background {
+  border: 10px solid transparent; }
+
+.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-background {
+  border-bottom-color: #565656;
+  left: 0;
+  top: 3px; }
+
+.tooltipster-sidetip.tooltipster-left .tooltipster-arrow-background {
+  border-left-color: #565656;
+  left: -3px;
+  top: 0; }
+
+.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-background {
+  border-right-color: #565656;
+  left: 3px;
+  top: 0; }
+
+.tooltipster-sidetip.tooltipster-top .tooltipster-arrow-background {
+  border-top-color: #565656;
+  left: 0;
+  top: -3px; }
+
+/* .tooltipster-arrow-border */
+.tooltipster-sidetip .tooltipster-arrow-border {
+  border: 10px solid transparent;
+  left: 0;
+  top: 0; }
+
+.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-border {
+  border-bottom-color: black; }
+
+.tooltipster-sidetip.tooltipster-left .tooltipster-arrow-border {
+  border-left-color: black; }
+
+.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-border {
+  border-right-color: black; }
+
+.tooltipster-sidetip.tooltipster-top .tooltipster-arrow-border {
+  border-top-color: black; }
+
+/* tooltipster-arrow-uncropped */
+.tooltipster-sidetip .tooltipster-arrow-uncropped {
+  position: relative; }
+
+.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-uncropped {
+  top: -10px; }
+
+.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-uncropped {
+  left: -10px; }
+
+/* CSS transition for when contenting is changing in a tooltip that is still open. The only properties that will NOT transition are: width, height, top, and left */
+.tooltipster-content-changing {
+  opacity: 0.5;
+  -webkit-transform: scale(1.1, 1.1);
+  -moz-transform: scale(1.1, 1.1);
+  -o-transform: scale(1.1, 1.1);
+  -ms-transform: scale(1.1, 1.1);
+  transform: scale(1.1, 1.1); }
+
+.tooltipster-sidetip .tooltipster-box,
+.tooltipster-box {
+  background-color: #555;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  border: none;
+  max-width: 250px;
+  padding: 0.75rem;
+  border-radius: 10px;
+  overflow: hidden; }
+  .tooltipster-sidetip .tooltipster-box .tooltipster-content,
+  .tooltipster-box .tooltipster-content {
+    font-weight: 600;
+    font-size: 0.9rem;
+    line-height: 1.1rem;
+    padding: 0;
+    overflow: hidden; }
+
+.tooltipster-sidetip.tooltipster-top .tooltipster-arrow-border,
+.tooltipster-sidetip.tooltipster-top .tooltipster-arrow-background,
+.tooltipster-top .tooltipster-arrow-border,
+.tooltipster-top .tooltipster-arrow-background {
+  border-top-color: #555; }
+
+.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-border,
+.tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-background,
+.tooltipster-bottom .tooltipster-arrow-border,
+.tooltipster-bottom .tooltipster-arrow-background {
+  border-bottom-color: #555; }
+
+.tooltipster-sidetip.tooltipster-left .tooltipster-arrow-border,
+.tooltipster-sidetip.tooltipster-left .tooltipster-arrow-background,
+.tooltipster-left .tooltipster-arrow-border,
+.tooltipster-left .tooltipster-arrow-background {
+  border-left-color: #555; }
+
+.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-border,
+.tooltipster-sidetip.tooltipster-right .tooltipster-arrow-background,
+.tooltipster-right .tooltipster-arrow-border,
+.tooltipster-right .tooltipster-arrow-background {
+  border-right-color: #555; }
+
+.tooltip-templates {
+  display: none; }
+
+.clippy-theme .tooltipster-box {
+  background-color: #FFF;
+  border-radius: 5px !important;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  border: 2px solid #D4D4D4;
+  max-width: 350px;
+  padding: 1rem;
+  border-radius: 10px; }
+  .clippy-theme .tooltipster-box .tooltipster-content {
+    font-weight: 400;
+    font-size: 0.9rem;
+    line-height: 1.2rem;
+    padding: 0; }
+    .clippy-theme .tooltipster-box .tooltipster-content h4, .clippy-theme .tooltipster-box .tooltipster-content p {
+      font-size: 0.9rem; }
+    .clippy-theme .tooltipster-box .tooltipster-content h4 {
+      font-weight: 600; }
+    .clippy-theme .tooltipster-box .tooltipster-content p {
+      margin-bottom: 0; }
+    .clippy-theme .tooltipster-box .tooltipster-content .button, .clippy-theme .tooltipster-box .tooltipster-content .file-custom .file-custom--button, .file-custom .clippy-theme .tooltipster-box .tooltipster-content .file-custom--button {
+      margin-top: 0.5rem; }
+.clippy-theme.tooltipster-top .tooltipster-arrow-border,
+.clippy-theme.tooltipster-top .tooltipster-arrow-background {
+  border-top-color: transparent; }
+.clippy-theme.tooltipster-bottom .tooltipster-arrow-border,
+.clippy-theme.tooltipster-bottom .tooltipster-arrow-background {
+  border-bottom-color: transparent; }
+.clippy-theme.tooltipster-left .tooltipster-arrow-border,
+.clippy-theme.tooltipster-left .tooltipster-arrow-background {
+  border-left-color: transparent; }
+.clippy-theme.tooltipster-right .tooltipster-arrow-border,
+.clippy-theme.tooltipster-right .tooltipster-arrow-background {
+  border-right-color: transparent; }
+
+/* Imported font family
+  ================================================== */
+/* Imported base components
+  ================================================== */
+/* Color Scale
+  ================================================== */
+/* Core Mixins
+  =========================================================================== */
+/* Actions Mixins
+  =========================================================================== */
+/* Tag Mixins
+  =========================================================================== */
+/* List Mixins
+  =========================================================================== */
+/* Core Variables
+  =========================================================================== */
+/* Core Utility Classes
+  =========================================================================== */
+.hide, .hidden, .is-hidden {
+  display: none !important; }
+
+.mobile-hide, .is-hidden_phone {
+  display: block;
+  display: none; }
+  @media all and (min-width: 40em) {
+    .mobile-hide, .is-hidden_phone {
+      display: block; } }
+
+.mobile-hide-inline, .is-hidden--inline_phone {
+  display: inline;
+  display: none; }
+  @media all and (min-width: 40em) {
+    .mobile-hide-inline, .is-hidden--inline_phone {
+      display: inline; } }
+
+.tablet-hide, .is-hidden_tablet {
+  display: block; }
+  @media all and (min-width: 40em) {
+    .tablet-hide, .is-hidden_tablet {
+      display: none; } }
+  @media all and (min-width: 64em) {
+    .tablet-hide, .is-hidden_tablet {
+      display: block; } }
+
+.tablet-hide-inline, .is-hidden--inline_tablet {
+  display: inline; }
+  @media all and (min-width: 40em) {
+    .tablet-hide-inline, .is-hidden--inline_tablet {
+      display: none; } }
+  @media all and (min-width: 64em) {
+    .tablet-hide-inline, .is-hidden--inline_tablet {
+      display: inline; } }
+
+@media all and (min-width: 64em) {
+  .desktop-hide, .is-hidden_desktop {
+    display: none; } }
+
+.pointer, .selectable {
+  cursor: pointer !important; }
+
+.remove-margin, .no-margin {
+  margin: 0 !important; }
+
+.remove-margin--top, .no-margin--top {
+  margin-top: 0 !important; }
+
+.remove-margin--right, .no-margin--right {
+  margin-right: 0 !important; }
+
+.remove-margin--bottom, .no-margin--bottom {
+  margin-bottom: 0 !important; }
+
+.remove-margin--left, .no-margin--left {
+  margin-left: 0 !important; }
+
+.remove-padding, .no-padding {
+  padding: 0 !important; }
+
+.remove-padding--top, .no-padding--top {
+  padding-top: 0 !important; }
+
+.remove-padding--right, .no-padding--right {
+  padding-right: 0 !important; }
+
+.remove-padding--bottom, .no-padding--bottom {
+  padding-bottom: 0 !important; }
+
+.remove-padding--left, .no-padding--left {
+  padding-left: 0 !important; }
+
+.remove-border {
+  border: none !important; }
+
+.float-left {
+  float: left !important; }
+
+.float-right {
+  float: right !important; }
+
+.float-none {
+  float: none !important; }
+
+.fixed {
+  position: fixed !important; }
+
+.relative {
+  position: relative !important; }
+
+.text-color--white {
+  color: #FFFFFF; }
+
+.text-color--black {
+  color: #000000; }
+
+.text-color--gray, .text-color--grey {
+  color: #6E6E6E; }
+
+.text-color--blue {
+  color: #3F70C9; }
+
+.text-color--green {
+  color: #09AA66; }
+
+.text-color--orange {
+  color: #FFA11F; }
+
+.text-color--purple {
+  color: #9F65AE; }
+
+.text-color--red {
+  color: #DA3D30; }
+
+.text-color--yellow {
+  color: #F2E670; }
+
+/* Core Extendables
+  =========================================================================== */
+.row, .app-menu .app-navigation {
+  overflow: auto; }
+
+.app-menu .app-navigation {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+/* Shadow Extendables
+=========================================================================== */
+.button--icon.button--icon--main:active {
+  -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  -moz-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5); }
+
+.button--icon.button--icon--main, .card.is-selectable:hover {
+  -webkit-box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  -moz-box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3); }
+
+/* Action Extendables
+  =========================================================================== */
+.button, .file-custom .file-custom--button, button, input[type='submit'], input[type='reset'], .button.button--round, button.button--round, input[type='submit'].button--round, input[type='reset'].button--round {
+  border-radius: 50px; }
+
+.button.button--smooth, .file-custom .button--smooth.file-custom--button, .file-custom .app-menu .app-context .app-title .file-custom--button.button--navigation, .app-menu .app-context .app-title .file-custom .file-custom--button.button--navigation, .app-menu .app-context .app-title .button.button--navigation, button.button--smooth, .app-menu .app-context .app-title button.button--navigation, input[type='submit'].button--smooth, .app-menu .app-context .app-title input[type='submit'].button--navigation, input[type='reset'].button--smooth, .app-menu .app-context .app-title input[type='reset'].button--navigation, .page-banner .button--banner {
+  border-radius: 5px; }
+
+.button.button--square, .file-custom .button--square.file-custom--button, button.button--square, input[type='submit'].button--square, input[type='reset'].button--square {
+  border-radius: 0; }
+
+/* Custom Scrollbar Extendables
+  =========================================================================== */
+/* Default base element styles
+  ================================================== */
+hr {
+  border: 0;
+  border-top: 2px solid #D4D4D4; }
+
+.dashing-app {
+  -webkit-overflow-scrolling: touch;
+  overflow: auto;
+  position: absolute;
+  width: 100%;
+  height: 100%; }
+
+/* Typography Variables
+  =========================================================================== */
+/* Typography Utility Classes
+  =========================================================================== */
+.text-align-center, .center-align, .align-center {
+  text-align: center !important; }
+
+.text-align-left, .left-align, .align-left {
+  text-align: left !important; }
+
+.text-align-right, .right-align, .align-right {
+  text-align: right !important; }
+
+.no-wrap {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden; }
+
+.break-word {
+  word-wrap: break-word; }
+
+/* Typography Styles
+  =========================================================================== */
+* {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility; }
+
+body {
+  background-color: #EDEDED;
+  font-family: "Source Sans Pro", sans-serif;
+  font-size: 1rem; }
+
+h1, h2, h3, h4, h5, h6 {
+  color: #222222;
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 600;
+  margin: 0; }
+
+h1, .font-size--xlarge {
+  font-size: 1.953rem; }
+
+h2, .font-size--large {
+  font-size: 1.563rem; }
+
+h3, .font-size--medium {
+  font-size: 1.25rem; }
+
+h4, .font-size--normal {
+  font-size: 1rem; }
+
+small, .font-size--small {
+  font-size: 0.9rem; }
+
+.font-size--xsmall {
+  font-size: 0.8rem; }
+
+a {
+  color: #3F70C9;
+  cursor: pointer;
+  font-weight: 600;
+  outline: none;
+  text-decoration: none; }
+  a:hover, a:focus {
+    color: #84A7ED; }
+
+p {
+  color: #222222;
+  color: #24292C;
+  font-size: 1rem;
+  line-height: 1.25rem; }
+
+strong, .strong {
+  font-weight: 600; }
+
+/* Setup Utility Classes
+  =========================================================================== */
+*,
+*:before,
+*:after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box; }
+
+html {
+  font-size: 100%; }
+  @media all and (min-width: 40em) {
+    html {
+      font-size: 105%; } }
+  @media all and (min-width: 64em) {
+    html {
+      font-size: 110%; } }
+
+/* Grid Styles
+  =========================================================================== */
+.row {
+  margin: auto;
+  max-width: 1200px;
+  padding-left: 1rem;
+  width: 100%; }
+  .row.row--nested {
+    padding-left: 0; }
+
+.column {
+  padding: 1rem;
+  padding-left: 0 !important; }
+  .column.column--nested {
+    padding-top: calc((1rem) / 2);
+    padding-bottom: calc((1rem) / 2); }
+    @media all and (max-width: 40em) {
+      .column.column--nested {
+        padding-right: 0; } }
+    @media all and (min-width: 40em) {
+      .column.column--nested:last-of-type {
+        padding-right: 0; } }
+  .column.column--full, .column.column--three-fourths, .column.column--two-thirds, .column.column--half, .column.column--third, .column.column--fourth, .column.column--sixth, .column.column--eighth {
+    width: 100%; }
+  @media all and (min-width: 40em) {
+    .column {
+      float: left; }
+      .column.flow-opposite {
+        float: right; }
+      .column.column--full {
+        float: none;
+        width: 100%; }
+      .column.column--three-fourths {
+        width: 75%; }
+      .column.column--two-thirds {
+        width: 66.666%; }
+      .column.column--half {
+        width: 50%; }
+      .column.column--third {
+        width: 33.333%; }
+      .column.column--fourth {
+        width: 25%; }
+      .column.column--sixth {
+        width: 16.666%; }
+      .column.column--eighth {
+        width: 12.5%; } }
+
+/* Flex Mixins
+  =========================================================================== */
+/* Flex Styles
+  =========================================================================== */
+.row-flex {
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex; }
+  .row-flex .column-flex {
+    -webkit-flex: 1;
+    -moz-box-flex: 1;
+    flex: 1;
+    margin: 1rem; }
+
+/* -----------------------------
+Fallback Classes (Must be First)
+-------------------------------- */
+.grid {
+  grid-template-columns: repeat(12, 1fr); }
+  @media all and (min-width: 40em) {
+    .grid .grid--full {
+      width: calc(100% - 1rem);
+      float: left; } }
+  @media all and (min-width: 40em) {
+    .grid .grid--five-sixths {
+      width: calc(83.3333% - 1rem);
+      float: left; } }
+  @media all and (min-width: 40em) {
+    .grid .grid--three-fourths {
+      width: calc(75% - 1rem);
+      float: left; } }
+  @media all and (min-width: 40em) {
+    .grid .grid--two-thirds {
+      width: calc(66.6666% - 1rem);
+      float: left; } }
+  @media all and (min-width: 40em) {
+    .grid .grid--half {
+      width: calc(50% - 1rem);
+      float: left; } }
+  @media all and (min-width: 40em) {
+    .grid .grid--third {
+      width: calc(33.3333% - 1rem);
+      float: left; } }
+  @media all and (min-width: 40em) {
+    .grid .grid--fourth {
+      width: calc(25% - 1rem);
+      float: left; } }
+  @media all and (min-width: 40em) {
+    .grid .grid--sixth {
+      width: calc(16.6666% - 1rem);
+      float: left; } }
+
+/* -----------------------------
+Fake "grid-gap" for Old Browsers
+-------------------------------- */
+.grid .grid--full, .grid .grid--half, .grid .grid--three-fourths, .grid .grid--fourth,
+.grid .grid--two-thirds, .grid .grid--five-sixths, .grid .grid--third, .grid .grid--sixth {
+  margin: 1rem 0; }
+  .grid .grid--full:first-of-type, .grid .grid--half:first-of-type, .grid .grid--three-fourths:first-of-type, .grid .grid--fourth:first-of-type,
+  .grid .grid--two-thirds:first-of-type, .grid .grid--five-sixths:first-of-type, .grid .grid--third:first-of-type, .grid .grid--sixth:first-of-type {
+    margin-top: 0; }
+  .grid .grid--full:last-of-type, .grid .grid--half:last-of-type, .grid .grid--three-fourths:last-of-type, .grid .grid--fourth:last-of-type,
+  .grid .grid--two-thirds:last-of-type, .grid .grid--five-sixths:last-of-type, .grid .grid--third:last-of-type, .grid .grid--sixth:last-of-type {
+    margin-bottom: 0; }
+  @media all and (min-width: 40em) {
+    .grid .grid--full, .grid .grid--half, .grid .grid--three-fourths, .grid .grid--fourth,
+    .grid .grid--two-thirds, .grid .grid--five-sixths, .grid .grid--third, .grid .grid--sixth {
+      margin: calc(1rem / 2); }
+      .grid .grid--full:first-of-type, .grid .grid--half:first-of-type, .grid .grid--three-fourths:first-of-type, .grid .grid--fourth:first-of-type,
+      .grid .grid--two-thirds:first-of-type, .grid .grid--five-sixths:first-of-type, .grid .grid--third:first-of-type, .grid .grid--sixth:first-of-type {
+        margin: calc(1rem / 2); }
+      .grid .grid--full:last-of-type, .grid .grid--half:last-of-type, .grid .grid--three-fourths:last-of-type, .grid .grid--fourth:last-of-type,
+      .grid .grid--two-thirds:last-of-type, .grid .grid--five-sixths:last-of-type, .grid .grid--third:last-of-type, .grid .grid--sixth:last-of-type {
+        margin: calc(1rem / 2); } }
+  @supports (display: grid) {
+    .grid .grid--full, .grid .grid--half, .grid .grid--three-fourths, .grid .grid--fourth,
+    .grid .grid--two-thirds, .grid .grid--five-sixths, .grid .grid--third, .grid .grid--sixth {
+      margin: 0; }
+      .grid .grid--full:first-of-type, .grid .grid--half:first-of-type, .grid .grid--three-fourths:first-of-type, .grid .grid--fourth:first-of-type,
+      .grid .grid--two-thirds:first-of-type, .grid .grid--five-sixths:first-of-type, .grid .grid--third:first-of-type, .grid .grid--sixth:first-of-type {
+        margin: 0; }
+      .grid .grid--full:last-of-type, .grid .grid--half:last-of-type, .grid .grid--three-fourths:last-of-type, .grid .grid--fourth:last-of-type,
+      .grid .grid--two-thirds:last-of-type, .grid .grid--five-sixths:last-of-type, .grid .grid--third:last-of-type, .grid .grid--sixth:last-of-type {
+        margin: 0; } }
+
+/* -----------------------------
+Utilities
+-------------------------------- */
+.grid-align-center {
+  align-items: center; }
+
+.grid-align-top {
+  align-items: start; }
+
+.grid-align-bottom {
+  align-items: end; }
+
+.grid-justify-center {
+  justify-items: center; }
+
+.grid-justify-left {
+  justify-items: start; }
+
+.grid-justify-right {
+  justify-items: end; }
+
+/* -----------------------------
+Actual CSS Grid Classes
+-------------------------------- */
+.grid-wrapper {
+  max-width: 1200px;
+  margin: auto;
+  width: 100%; }
+
+@supports (display: grid) {
+  .grid-layout,
+  .grid-padding {
+    padding: 1rem; } }
+
+.grid {
+  display: block;
+  overflow: auto;
+  grid-template-columns: repeat(12, 1fr); }
+  @supports (display: grid) {
+    .grid {
+      display: grid;
+      grid-gap: 1rem; } }
+  @supports (display: grid) {
+    .grid * {
+      grid-column: 1 / -1; }
+      @media all and (min-width: 40em) {
+        .grid * {
+          grid-column: span 12; }
+          @supports (display: grid) {
+            .grid * {
+              width: auto; } } } }
+  .grid .grid--full {
+    grid-column: 1 / -1; }
+    @media all and (min-width: 40em) {
+      .grid .grid--full {
+        grid-column: span 12; }
+        @supports (display: grid) {
+          .grid .grid--full {
+            width: auto; } } }
+  .grid .grid--five-sixths {
+    grid-column: 1 / -1; }
+    @media all and (min-width: 40em) {
+      .grid .grid--five-sixths {
+        grid-column: span 10; }
+        @supports (display: grid) {
+          .grid .grid--five-sixths {
+            width: auto; } } }
+  .grid .grid--three-fourths {
+    grid-column: 1 / -1; }
+    @media all and (min-width: 40em) {
+      .grid .grid--three-fourths {
+        grid-column: span 9; }
+        @supports (display: grid) {
+          .grid .grid--three-fourths {
+            width: auto; } } }
+  .grid .grid--two-thirds {
+    grid-column: 1 / -1; }
+    @media all and (min-width: 40em) {
+      .grid .grid--two-thirds {
+        grid-column: span 8; }
+        @supports (display: grid) {
+          .grid .grid--two-thirds {
+            width: auto; } } }
+  .grid .grid--half {
+    grid-column: 1 / -1; }
+    @media all and (min-width: 40em) {
+      .grid .grid--half {
+        grid-column: span 6; }
+        @supports (display: grid) {
+          .grid .grid--half {
+            width: auto; } } }
+  .grid .grid--third {
+    grid-column: 1 / -1; }
+    @media all and (min-width: 40em) {
+      .grid .grid--third {
+        grid-column: span 4; }
+        @supports (display: grid) {
+          .grid .grid--third {
+            width: auto; } } }
+  .grid .grid--fourth {
+    grid-column: 1 / -1; }
+    @media all and (min-width: 40em) {
+      .grid .grid--fourth {
+        grid-column: span 3; }
+        @supports (display: grid) {
+          .grid .grid--fourth {
+            width: auto; } } }
+  .grid .grid--sixth {
+    grid-column: 1 / -1; }
+    @media all and (min-width: 40em) {
+      .grid .grid--sixth {
+        grid-column: span 2; }
+        @supports (display: grid) {
+          .grid .grid--sixth {
+            width: auto; } } }
+
+.grid .card {
+  margin: 0; }
+
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0; }
+  fieldset label {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+    text-align: left; }
+    fieldset label.inline {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      -o-user-select: none;
+      user-select: none;
+      font-size: 1rem;
+      display: inline-block;
+      font-weight: normal;
+      cursor: pointer; }
+  fieldset select, fieldset textarea, fieldset input[type="date"], fieldset input[type="time"], fieldset input[type="email"], fieldset input[type="month"], fieldset input[type="number"], fieldset input[type="password"], fieldset input[type="tel"], fieldset input[type="text"] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background-color: #FFFFFF;
+    border: 2px solid #E0E0E0;
+    border-radius: 5px;
+    font-size: 1rem;
+    max-width: 100%;
+    padding: 0.6rem;
+    width: 100%; }
+    fieldset select:focus, fieldset textarea:focus, fieldset input[type="date"]:focus, fieldset input[type="time"]:focus, fieldset input[type="email"]:focus, fieldset input[type="month"]:focus, fieldset input[type="number"]:focus, fieldset input[type="password"]:focus, fieldset input[type="tel"]:focus, fieldset input[type="text"]:focus {
+      border-color: #3F70C9;
+      outline-color: transparent;
+      outline-style: none; }
+    fieldset select[disabled], fieldset textarea[disabled], fieldset input[type="date"][disabled], fieldset input[type="time"][disabled], fieldset input[type="email"][disabled], fieldset input[type="month"][disabled], fieldset input[type="number"][disabled], fieldset input[type="password"][disabled], fieldset input[type="tel"][disabled], fieldset input[type="text"][disabled] {
+      background-color: #EDEDED !important;
+      border-color: #EDEDED !important;
+      cursor: default !important; }
+  fieldset input[type="date"],
+  fieldset input[type="time"],
+  fieldset input[type="month"] {
+    min-height: 2.75rem; }
+  fieldset input[type=checkbox],
+  fieldset input[type=radio] {
+    float: left;
+    margin-top: 0.3rem;
+    margin-right: 0.5rem; }
+  fieldset textarea {
+    resize: vertical; }
+  fieldset select {
+    cursor: pointer; }
+  fieldset .input--add-on {
+    display: flex; }
+    fieldset .input--add-on .add-on--field,
+    fieldset .input--add-on .add-on--before,
+    fieldset .input--add-on .add-on--after {
+      width: 5rem;
+      flex-grow: 1; }
+      @media all and (min-width: 40em) {
+        fieldset .input--add-on .add-on--field,
+        fieldset .input--add-on .add-on--before,
+        fieldset .input--add-on .add-on--after {
+          width: auto; } }
+    fieldset .input--add-on .add-on--field,
+    fieldset .input--add-on .add-on--before {
+      border-radius: 5px 0 0 5px;
+      border-right: none; }
+    fieldset .input--add-on .add-on--after {
+      border-radius: 0 5px 5px 0; }
+    fieldset .input--add-on select.add-on--after,
+    fieldset .input--add-on select.add-on--before {
+      padding-right: 2rem;
+      flex: none; }
+    fieldset .input--add-on .add-on--button {
+      border-radius: 0 5px 5px 0 !important;
+      padding-top: calc(0.6rem + 3px);
+      padding-bottom: calc(0.6rem + 3px);
+      margin: 0; }
+      fieldset .input--add-on .add-on--button.button--border {
+        background-color: rgba(255, 255, 255, 0);
+        border-color: #E0E0E0;
+        color: #E0E0E0;
+        color: #878787; }
+        fieldset .input--add-on .add-on--button.button--border .dashing-icon:before, fieldset .input--add-on .add-on--button.button--border i.dashing-tooltip:before,
+        fieldset .input--add-on .add-on--button.button--border i.dashing-clippy:before, fieldset .input--add-on .add-on--button.button--border .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title fieldset .input--add-on .add-on--button.button--border .button--navigation:before {
+          color: #E0E0E0; }
+        fieldset .input--add-on .add-on--button.button--border:hover, fieldset .input--add-on .add-on--button.button--border:focus {
+          background-color: #c7c7c7;
+          border-color: rgba(255, 255, 255, 0);
+          color: #FFFFFF; }
+          fieldset .input--add-on .add-on--button.button--border:hover .dashing-icon:before, fieldset .input--add-on .add-on--button.button--border:hover i.dashing-tooltip:before,
+          fieldset .input--add-on .add-on--button.button--border:hover i.dashing-clippy:before, fieldset .input--add-on .add-on--button.button--border:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title fieldset .input--add-on .add-on--button.button--border:hover .button--navigation:before, fieldset .input--add-on .add-on--button.button--border:focus .dashing-icon:before, fieldset .input--add-on .add-on--button.button--border:focus i.dashing-tooltip:before,
+          fieldset .input--add-on .add-on--button.button--border:focus i.dashing-clippy:before, fieldset .input--add-on .add-on--button.button--border:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title fieldset .input--add-on .add-on--button.button--border:focus .button--navigation:before {
+            color: #FFFFFF;
+            transition: all 50ms ease-in-out; }
+        fieldset .input--add-on .add-on--button.button--border:active {
+          background-color: #bababa; }
+        fieldset .input--add-on .add-on--button.button--border .dashing-icon:before, fieldset .input--add-on .add-on--button.button--border i.dashing-tooltip:before,
+        fieldset .input--add-on .add-on--button.button--border i.dashing-clippy:before, fieldset .input--add-on .add-on--button.button--border .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title fieldset .input--add-on .add-on--button.button--border .button--navigation:before {
+          color: #878787; }
+  fieldset.select--has-icon,
+  fieldset .select--has-icon {
+    position: relative; }
+    fieldset.select--has-icon:after,
+    fieldset .select--has-icon:after {
+      content: '\e800';
+      color: #A1A1A1;
+      font-family: 'dashing-icons';
+      font-size: 12px;
+      font-weight: 600;
+      pointer-events: none;
+      position: absolute;
+      right: 2rem;
+      bottom: calc(1rem * 2); }
+    fieldset.select--has-icon.has-error:after,
+    fieldset .select--has-icon.has-error:after {
+      color: #F76553; }
+    fieldset.select--has-icon.has-warning:after,
+    fieldset .select--has-icon.has-warning:after {
+      color: #F7AD4B; }
+    fieldset.select--has-icon.column--nested:after,
+    fieldset .select--has-icon.column--nested:after {
+      right: 1.5rem;
+      bottom: 1.5rem; }
+    @media all and (min-width: 40em) {
+      fieldset.select--has-icon.column--nested:last-of-type:after,
+      fieldset .select--has-icon.column--nested:last-of-type:after {
+        right: 0.5rem; } }
+    fieldset.select--has-icon select::-ms-expand,
+    fieldset .select--has-icon select::-ms-expand {
+      display: none; }
+
+/* Form States
+*/
+fieldset .message {
+  color: #6E6E6E;
+  list-style: none;
+  margin: 0;
+  margin-top: 0.4rem;
+  overflow: auto;
+  padding: 0; }
+  fieldset .message li {
+    float: left;
+    font-size: 1rem;
+    margin-right: 0.5rem; }
+fieldset.has-error label, fieldset.has-error select, fieldset.has-error textarea, fieldset.has-error input[type="date"], fieldset.has-error input[type="time"], fieldset.has-error input[type="email"], fieldset.has-error input[type="month"], fieldset.has-error input[type="number"], fieldset.has-error input[type="password"], fieldset.has-error input[type="tel"], fieldset.has-error input[type="text"],
+fieldset .has-error label,
+fieldset .has-error select,
+fieldset .has-error textarea,
+fieldset .has-error input[type="date"],
+fieldset .has-error input[type="time"],
+fieldset .has-error input[type="email"],
+fieldset .has-error input[type="month"],
+fieldset .has-error input[type="number"],
+fieldset .has-error input[type="password"],
+fieldset .has-error input[type="tel"],
+fieldset .has-error input[type="text"] {
+  color: #DA3D30;
+  border-color: #FF9886; }
+fieldset.has-error select:focus, fieldset.has-error textarea:focus, fieldset.has-error input[type="date"]:focus, fieldset.has-error input[type="time"]:focus, fieldset.has-error input[type="email"]:focus, fieldset.has-error input[type="month"]:focus, fieldset.has-error input[type="number"]:focus, fieldset.has-error input[type="password"]:focus, fieldset.has-error input[type="tel"]:focus, fieldset.has-error input[type="text"]:focus,
+fieldset .has-error select:focus,
+fieldset .has-error textarea:focus,
+fieldset .has-error input[type="date"]:focus,
+fieldset .has-error input[type="time"]:focus,
+fieldset .has-error input[type="email"]:focus,
+fieldset .has-error input[type="month"]:focus,
+fieldset .has-error input[type="number"]:focus,
+fieldset .has-error input[type="password"]:focus,
+fieldset .has-error input[type="tel"]:focus,
+fieldset .has-error input[type="text"]:focus {
+  border-color: #DA3D30; }
+fieldset.has-error .message li,
+fieldset .has-error .message li {
+  color: #DA3D30; }
+fieldset.has-warning label, fieldset.has-warning select, fieldset.has-warning textarea, fieldset.has-warning input[type="date"], fieldset.has-warning input[type="time"], fieldset.has-warning input[type="email"], fieldset.has-warning input[type="month"], fieldset.has-warning input[type="number"], fieldset.has-warning input[type="password"], fieldset.has-warning input[type="tel"], fieldset.has-warning input[type="text"],
+fieldset .has-warning label,
+fieldset .has-warning select,
+fieldset .has-warning textarea,
+fieldset .has-warning input[type="date"],
+fieldset .has-warning input[type="time"],
+fieldset .has-warning input[type="email"],
+fieldset .has-warning input[type="month"],
+fieldset .has-warning input[type="number"],
+fieldset .has-warning input[type="password"],
+fieldset .has-warning input[type="tel"],
+fieldset .has-warning input[type="text"] {
+  color: #FFA11F;
+  border-color: #FFC664; }
+fieldset.has-warning select:focus, fieldset.has-warning textarea:focus, fieldset.has-warning input[type="date"]:focus, fieldset.has-warning input[type="time"]:focus, fieldset.has-warning input[type="email"]:focus, fieldset.has-warning input[type="month"]:focus, fieldset.has-warning input[type="number"]:focus, fieldset.has-warning input[type="password"]:focus, fieldset.has-warning input[type="tel"]:focus, fieldset.has-warning input[type="text"]:focus,
+fieldset .has-warning select:focus,
+fieldset .has-warning textarea:focus,
+fieldset .has-warning input[type="date"]:focus,
+fieldset .has-warning input[type="time"]:focus,
+fieldset .has-warning input[type="email"]:focus,
+fieldset .has-warning input[type="month"]:focus,
+fieldset .has-warning input[type="number"]:focus,
+fieldset .has-warning input[type="password"]:focus,
+fieldset .has-warning input[type="tel"]:focus,
+fieldset .has-warning input[type="text"]:focus {
+  border-color: #FFA11F; }
+fieldset.has-warning .message li,
+fieldset .has-warning .message li {
+  color: #FFA11F; }
+
+/* Form Variables
+  =========================================================================== */
+/* Custom Checkboxes
+  ================================================== */
+.checkbox--custom, .checkbox-card,
+.radio--custom,
+.radio-card {
+  display: flex; }
+  .checkbox--custom input, .checkbox-card input,
+  .radio--custom input,
+  .radio-card input {
+    opacity: 0;
+    position: absolute;
+    z-index: -1; }
+  .checkbox--custom label, .checkbox-card label,
+  .radio--custom label,
+  .radio-card label {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+    align-items: baseline;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 1rem;
+    font-weight: normal;
+    margin: 0.2rem 0; }
+    @supports (display: flex) {
+      .checkbox--custom label, .checkbox-card label,
+      .radio--custom label,
+      .radio-card label {
+        display: flex; } }
+    .checkbox--custom label:before, .checkbox-card label:before,
+    .radio--custom label:before,
+    .radio-card label:before {
+      border: 2px solid #D4D4D4;
+      display: inline-block;
+      color: transparent;
+      height: 20px;
+      width: 20px;
+      margin-right: 0.5rem; }
+  .checkbox--custom.inline, .inline.checkbox-card,
+  .radio--custom.inline,
+  .inline.radio-card {
+    display: inline-block;
+    margin-right: 1rem; }
+    .checkbox--custom.inline .label:before, .inline.checkbox-card .label:before,
+    .radio--custom.inline .label:before,
+    .inline.radio-card .label:before {
+      display: inline-block; }
+
+.checkbox--custom label:before, .checkbox-card label:before {
+  content: '\e835';
+  border-radius: 5px;
+  font-family: 'dashing-icons';
+  font-size: 12px;
+  padding: 2px; }
+@media all and (max-width: 40em) {
+  .checkbox--custom, .checkbox-card {
+    margin: 0.2rem 0 0 0; }
+    .checkbox--custom label:not(.card), .checkbox-card label:not(.card) {
+      margin: 0.4rem 0 0.25rem 0; }
+      .checkbox--custom label:not(.card):before, .checkbox-card label:not(.card):before {
+        border-radius: 8px;
+        font-size: 16px;
+        height: 32px;
+        width: 32px;
+        margin-top: 2px;
+        margin-right: 0.5rem;
+        padding: 6px; } }
+.checkbox--custom.inline label:before, .inline.checkbox-card label:before {
+  margin-right: 0.3rem; }
+.checkbox--custom input:hover ~ label, .checkbox-card input:hover ~ label {
+  color: rgba(0, 0, 0, 0.6); }
+  .checkbox--custom input:hover ~ label:before, .checkbox-card input:hover ~ label:before {
+    color: #D4D4D4; }
+.checkbox--custom input:checked ~ label:before, .checkbox-card input:checked ~ label:before, .checkbox--custom input:active ~ label:before, .checkbox-card input:active ~ label:before {
+  color: #FFFFFF;
+  background-color: #3F70C9;
+  border: 2px solid #3F70C9; }
+.checkbox--custom input:focus ~ label:before, .checkbox-card input:focus ~ label:before {
+  box-shadow: 0 0 0 2px #9DC0FF; }
+.checkbox--custom input[disabled] ~ label, .checkbox-card input[disabled] ~ label,
+.checkbox--custom input[disabled]:active ~ label,
+.checkbox-card input[disabled]:active ~ label,
+.checkbox--custom input[disabled]:checked ~ label,
+.checkbox-card input[disabled]:checked ~ label {
+  cursor: default;
+  pointer-events: none; }
+  .checkbox--custom input[disabled] ~ label:before, .checkbox-card input[disabled] ~ label:before,
+  .checkbox--custom input[disabled]:active ~ label:before,
+  .checkbox-card input[disabled]:active ~ label:before,
+  .checkbox--custom input[disabled]:checked ~ label:before,
+  .checkbox-card input[disabled]:checked ~ label:before {
+    border-color: #E0E0E0;
+    background-color: #E0E0E0; }
+.checkbox--custom input[disabled]:active ~ label:before, .checkbox-card input[disabled]:active ~ label:before,
+.checkbox--custom input[disabled]:checked ~ label:before,
+.checkbox-card input[disabled]:checked ~ label:before {
+  color: #878787; }
+.checkbox--custom.has-error label:before, .has-error.checkbox-card label:before, .has-error .checkbox--custom label:before, .has-error .checkbox-card label:before {
+  border: 2px solid #F76553; }
+.checkbox--custom.has-error input:hover ~ label, .has-error.checkbox-card input:hover ~ label, .has-error .checkbox--custom input:hover ~ label, .has-error .checkbox-card input:hover ~ label {
+  color: rgba(218, 61, 48, 0.6); }
+  .checkbox--custom.has-error input:hover ~ label:before, .has-error.checkbox-card input:hover ~ label:before, .has-error .checkbox--custom input:hover ~ label:before, .has-error .checkbox-card input:hover ~ label:before {
+    color: #FF9886; }
+.checkbox--custom.has-error input:checked ~ label:before, .has-error.checkbox-card input:checked ~ label:before, .checkbox--custom.has-error input:active ~ label:before, .has-error.checkbox-card input:active ~ label:before, .has-error .checkbox--custom input:checked ~ label:before, .has-error .checkbox-card input:checked ~ label:before, .has-error .checkbox--custom input:active ~ label:before, .has-error .checkbox-card input:active ~ label:before {
+  color: #FFFFFF;
+  background-color: #DD4B39;
+  border: 2px solid #DD4B39; }
+.checkbox--custom.has-error input:focus ~ label:before, .has-error.checkbox-card input:focus ~ label:before, .has-error .checkbox--custom input:focus ~ label:before, .has-error .checkbox-card input:focus ~ label:before {
+  box-shadow: 0 0 0 2px #FF9886; }
+.checkbox--custom.has-warning label:before, .has-warning.checkbox-card label:before, .has-warning .checkbox--custom label:before, .has-warning .checkbox-card label:before {
+  border: 2px solid #F7AD4B; }
+.checkbox--custom.has-warning input:hover ~ label, .has-warning.checkbox-card input:hover ~ label, .has-warning .checkbox--custom input:hover ~ label, .has-warning .checkbox-card input:hover ~ label {
+  color: rgba(255, 161, 31, 0.6); }
+  .checkbox--custom.has-warning input:hover ~ label:before, .has-warning.checkbox-card input:hover ~ label:before, .has-warning .checkbox--custom input:hover ~ label:before, .has-warning .checkbox-card input:hover ~ label:before {
+    color: #FFC664; }
+.checkbox--custom.has-warning input:checked ~ label:before, .has-warning.checkbox-card input:checked ~ label:before, .checkbox--custom.has-warning input:active ~ label:before, .has-warning.checkbox-card input:active ~ label:before, .has-warning .checkbox--custom input:checked ~ label:before, .has-warning .checkbox-card input:checked ~ label:before, .has-warning .checkbox--custom input:active ~ label:before, .has-warning .checkbox-card input:active ~ label:before {
+  color: #FFFFFF;
+  background-color: #F7AD4B;
+  border: 2px solid #F7AD4B; }
+.checkbox--custom.has-warning input:focus ~ label:before, .has-warning.checkbox-card input:focus ~ label:before, .has-warning .checkbox--custom input:focus ~ label:before, .has-warning .checkbox-card input:focus ~ label:before {
+  box-shadow: 0 0 0 2px #FFE07E; }
+
+/* Custom Radio Buttons
+  ================================================== */
+.radio--custom label:before, .radio-card label:before {
+  content: '•';
+  border-radius: 50px;
+  font-size: 1.7rem;
+  line-height: 12px;
+  padding: 0 4px; }
+  @media all and (min-width: 40em) {
+    .radio--custom label:before, .radio-card label:before {
+      font-size: 1.5rem; } }
+@media all and (max-width: 40em) {
+  .radio--custom label:not(.card):before, .radio-card label:not(.card):before {
+    font-size: 3rem;
+    line-height: 20px;
+    padding: 0 7px;
+    height: 32px;
+    width: 32px; } }
+@-moz-document url-prefix() {
+  .radio--custom label:before, .radio-card label:before {
+    font-size: 1.6rem; }
+  @media all and (max-width: 40em) {
+    .radio--custom label:not(.card):before, .radio-card label:not(.card):before {
+      line-height: 20px;
+      padding: 0 7px;
+      font-size: 3rem;
+      height: 32px;
+      width: 32px; } } }
+.radio--custom input:hover:not(:checked) ~ label, .radio-card input:hover:not(:checked) ~ label {
+  color: rgba(0, 0, 0, 0.6); }
+  .radio--custom input:hover:not(:checked) ~ label:before, .radio-card input:hover:not(:checked) ~ label:before {
+    color: #D4D4D4; }
+.radio--custom input:checked ~ label:before, .radio-card input:checked ~ label:before {
+  color: #FFFFFF; }
+.radio--custom input:checked ~ label:before, .radio-card input:checked ~ label:before {
+  background-color: #3F70C9;
+  border-color: #3F70C9;
+  color: #FFFFFF; }
+.radio--custom input:focus ~ label:before, .radio-card input:focus ~ label:before {
+  box-shadow: 0 0 0 2px #9DC0FF; }
+.radio--custom input[disabled] ~ label, .radio-card input[disabled] ~ label,
+.radio--custom input[disabled]:active ~ label,
+.radio-card input[disabled]:active ~ label,
+.radio--custom input[disabled]:checked ~ label,
+.radio-card input[disabled]:checked ~ label {
+  cursor: default;
+  pointer-events: none; }
+  .radio--custom input[disabled] ~ label:before, .radio-card input[disabled] ~ label:before,
+  .radio--custom input[disabled]:active ~ label:before,
+  .radio-card input[disabled]:active ~ label:before,
+  .radio--custom input[disabled]:checked ~ label:before,
+  .radio-card input[disabled]:checked ~ label:before {
+    border-color: #E0E0E0;
+    background-color: #E0E0E0; }
+.radio--custom input[disabled]:active ~ label:before, .radio-card input[disabled]:active ~ label:before,
+.radio--custom input[disabled]:checked ~ label:before,
+.radio-card input[disabled]:checked ~ label:before {
+  color: #878787; }
+.radio--custom.has-error label:before, .has-error.radio-card label:before, .has-error .radio--custom label:before, .has-error .radio-card label:before {
+  border: 2px solid #F76553; }
+.radio--custom.has-error input:hover:not(:checked) ~ label, .has-error.radio-card input:hover:not(:checked) ~ label, .has-error .radio--custom input:hover:not(:checked) ~ label, .has-error .radio-card input:hover:not(:checked) ~ label {
+  color: rgba(218, 61, 48, 0.6); }
+  .radio--custom.has-error input:hover:not(:checked) ~ label:before, .has-error.radio-card input:hover:not(:checked) ~ label:before, .has-error .radio--custom input:hover:not(:checked) ~ label:before, .has-error .radio-card input:hover:not(:checked) ~ label:before {
+    color: #FF9886; }
+.radio--custom.has-error input:checked ~ label:before, .has-error.radio-card input:checked ~ label:before, .has-error .radio--custom input:checked ~ label:before, .has-error .radio-card input:checked ~ label:before {
+  background-color: #DD4B39;
+  border-color: #DD4B39;
+  color: #FFFFFF; }
+.radio--custom.has-error input:focus ~ label:before, .has-error.radio-card input:focus ~ label:before, .has-error .radio--custom input:focus ~ label:before, .has-error .radio-card input:focus ~ label:before {
+  box-shadow: 0 0 0 2px #FF9886; }
+.radio--custom.has-warning label:before, .has-warning.radio-card label:before, .has-warning .radio--custom label:before, .has-warning .radio-card label:before {
+  border: 2px solid #F7AD4B; }
+.radio--custom.has-warning input:hover:not(:checked) ~ label, .has-warning.radio-card input:hover:not(:checked) ~ label, .has-warning .radio--custom input:hover:not(:checked) ~ label, .has-warning .radio-card input:hover:not(:checked) ~ label {
+  color: rgba(255, 161, 31, 0.6); }
+  .radio--custom.has-warning input:hover:not(:checked) ~ label:before, .has-warning.radio-card input:hover:not(:checked) ~ label:before, .has-warning .radio--custom input:hover:not(:checked) ~ label:before, .has-warning .radio-card input:hover:not(:checked) ~ label:before {
+    color: #FFC664; }
+.radio--custom.has-warning input:checked ~ label:before, .has-warning.radio-card input:checked ~ label:before, .has-warning .radio--custom input:checked ~ label:before, .has-warning .radio-card input:checked ~ label:before {
+  background-color: #F7AD4B;
+  border-color: #F7AD4B;
+  color: #FFFFFF; }
+.radio--custom.has-warning input:focus ~ label:before, .has-warning.radio-card input:focus ~ label:before, .has-warning .radio--custom input:focus ~ label:before, .has-warning .radio-card input:focus ~ label:before {
+  box-shadow: 0 0 0 2px #FFE07E; }
+
+/* Custom Range Slider
+  ================================================== */
+.range--custom {
+  width: 10rem;
+  margin: 0 auto; }
+  .range--custom input[type="range"] {
+    -webkit-appearance: none;
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+    background: none;
+    border: none;
+    border-radius: 30px;
+    cursor: pointer;
+    width: 100%;
+    margin: 0;
+    min-height: 2.5rem;
+    outline: none; }
+  .range--custom input[type="range"]::-webkit-slider-runnable-track {
+    -webkit-appearance: none;
+    background-color: #D4D4D4;
+    border-radius: 30px;
+    height: 0.5rem; }
+    .range--custom input[type="range"]::-webkit-slider-runnable-track:active {
+      background-color: #C7C7C7; }
+  .range--custom input[type="range"]::-moz-range-track {
+    border: inherit;
+    background-color: #D4D4D4;
+    border-radius: 30px;
+    height: 0.5rem; }
+    .range--custom input[type="range"]::-moz-range-track:active {
+      background-color: #C7C7C7; }
+  .range--custom input[type=range]::-moz-focus-outer {
+    border: 0; }
+  .range--custom input[type="range"]::-ms-track {
+    border: inherit;
+    color: transparent;
+    /* don't drawn vertical reference line */
+    background: transparent; }
+  .range--custom input[type="range"]::-ms-fill-lower,
+  .range--custom input[type="range"]::-ms-fill-upper {
+    background: transparent; }
+  .range--custom input[type="range"]::-ms-tooltip {
+    display: none; }
+  .range--custom input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    background-color: #FFFFFF;
+    border: 2px solid #D4D4D4;
+    width: 20px;
+    height: 20px;
+    border-radius: 30px;
+    margin-top: -5px; }
+  .range--custom input[type="range"]::-moz-range-thumb {
+    background-color: #FFFFFF;
+    border: 2px solid #D4D4D4;
+    width: 20px;
+    height: 20px;
+    border-radius: 30px; }
+  .range--custom input[type="range"]::-ms-thumb {
+    -webkit-appearance: none;
+    background-color: #FFFFFF;
+    border: 2px solid #D4D4D4;
+    width: 20px;
+    height: 20px; }
+
+/* Custom File Upload
+  ================================================== */
+.file-custom {
+  float: left; }
+  .file-custom .file-custom--button {
+    display: inline-block;
+    padding: 6px 12px;
+    cursor: pointer; }
+  .file-custom ~ input[type="file"] {
+    display: none; }
+
+/* Custom Toggle Switch
+================================================== */
+.switch {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+  display: inline-block;
+  position: relative;
+  width: 50px; }
+  .switch .switch--checkbox {
+    display: none; }
+  .switch .switch--label {
+    border-radius: 50px;
+    background-color: #C7C7C7;
+    cursor: pointer;
+    display: block;
+    height: 25px;
+    margin: 0;
+    overflow: hidden; }
+  label + .switch {
+    top: 6px;
+    margin-left: 0.2rem; }
+  .switch.switch--has-text .onoffswitch-inner:before {
+    content: "on";
+    padding-left: 0.5rem; }
+  .switch.switch--has-text .onoffswitch-inner:after {
+    content: "inactive";
+    float: right;
+    padding-right: 0.5rem; }
+  .switch .switch--inner {
+    -webkit-transition: all 0.05s ease-in 0s;
+    -moz-transition: all 0.05s ease-in 0s;
+    -o-transition: all 0.05s ease-in 0s;
+    -ms-transition: all 0.05s ease-in 0s;
+    transition: all 0.05s ease-in 0s;
+    display: block;
+    width: 200%;
+    margin-left: -100%; }
+    .switch .switch--inner:before, .switch .switch--inner:after {
+      color: #FFFFFF;
+      display: block;
+      float: left;
+      height: 2rem;
+      padding: 0;
+      line-height: 26px;
+      font-size: .8rem;
+      text-transform: uppercase;
+      width: 50%; }
+    .switch .switch--inner:before {
+      background-color: #3F70C9;
+      content: ""; }
+    .switch .switch--inner:after {
+      background-color: #C7C7C7;
+      content: ""; }
+  .switch .switch--handle {
+    -webkit-transition: all 0.05s ease-in 0s;
+    -moz-transition: all 0.05s ease-in 0s;
+    -o-transition: all 0.05s ease-in 0s;
+    -ms-transition: all 0.05s ease-in 0s;
+    transition: all 0.05s ease-in 0s;
+    background-color: #FFFFFF;
+    border-radius: 50%;
+    display: block;
+    margin: 3px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 25px;
+    width: 19px; }
+  .switch .switch--checkbox:checked +
+  .switch--label .switch--inner {
+    margin-left: 0; }
+  .switch .switch--checkbox:checked +
+  .switch--label .switch--handle {
+    right: 0; }
+
+.checkbox-card,
+.radio-card {
+  display: inline-flex;
+  margin-right: 0.5rem; }
+  .checkbox-card .card,
+  .radio-card .card {
+    float: none;
+    margin: 0;
+    padding: 1rem; }
+    .checkbox-card .card:before,
+    .radio-card .card:before {
+      display: inline-block; }
+    .checkbox-card .card.disabled,
+    .radio-card .card.disabled {
+      background-color: #D4D4D4;
+      border-color: #D4D4D4;
+      pointer-events: none;
+      opacity: 0.4;
+      color: #555555; }
+    .checkbox-card .card.center-align, .checkbox-card .card.align-center,
+    .radio-card .card.center-align,
+    .radio-card .card.align-center {
+      float: none; }
+  .checkbox-card.is-block, .checkbox-card.block,
+  .radio-card.is-block,
+  .radio-card.block {
+    display: block;
+    margin-bottom: 0.5rem;
+    width: 100%; }
+  .checkbox-card input:focus ~ label:before,
+  .radio-card input:focus ~ label:before {
+    box-shadow: none; }
+  .checkbox-card input:focus ~ label,
+  .radio-card input:focus ~ label {
+    box-shadow: 0 0 0 2px #9DC0FF; }
+  .checkbox-card input:checked ~ label, .checkbox-card input:active ~ label,
+  .radio-card input:checked ~ label,
+  .radio-card input:active ~ label {
+    color: #3F70C9;
+    border: 2px solid #3F70C9; }
+  .checkbox-card input[disabled] ~ label,
+  .checkbox-card input[disabled]:active ~ label,
+  .checkbox-card input[disabled]:checked ~ label,
+  .radio-card input[disabled] ~ label,
+  .radio-card input[disabled]:active ~ label,
+  .radio-card input[disabled]:checked ~ label {
+    cursor: default;
+    pointer-events: none; }
+    .checkbox-card input[disabled] ~ label:before,
+    .checkbox-card input[disabled]:active ~ label:before,
+    .checkbox-card input[disabled]:checked ~ label:before,
+    .radio-card input[disabled] ~ label:before,
+    .radio-card input[disabled]:active ~ label:before,
+    .radio-card input[disabled]:checked ~ label:before {
+      border-color: #A1A1A1 !important;
+      background-color: #D4D4D4 !important; }
+  .checkbox-card.checkbox-card--small .card,
+  .radio-card.checkbox-card--small .card {
+    padding: calc(1rem / 2); }
+  .checkbox-card.radio-card--small .card,
+  .radio-card.radio-card--small .card {
+    padding: calc(1rem / 2); }
+
+.radio-card .card:before {
+  top: calc(1rem + 2px);
+  left: 1rem; }
+.radio-card.radio-card--small .card:before {
+  top: calc((1rem / 2) + 2px);
+  left: calc((1rem / 2) + 3px); }
+
+/* Actions Variables
+  =========================================================================== */
+/* Actions Extendables
+  =========================================================================== */
+.button, .file-custom .file-custom--button, button, input[type='submit'], input[type='reset'], .app-menu .app-navigation li a {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  outline: none;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: all 50ms ease-in-out; }
+  .button:first-of-type, .file-custom .file-custom--button:first-of-type, button:first-of-type, input[type='submit']:first-of-type, input[type='reset']:first-of-type, .app-menu .app-navigation li a:first-of-type {
+    margin-left: 0; }
+  .button:last-of-type, .file-custom .file-custom--button:last-of-type, button:last-of-type, input[type='submit']:last-of-type, input[type='reset']:last-of-type, .app-menu .app-navigation li a:last-of-type {
+    margin-right: 0; }
+  .button:hover, .file-custom .file-custom--button:hover, button:hover, input[type='submit']:hover, input[type='reset']:hover, .app-menu .app-navigation li a:hover {
+    transition: all .1s ease-in-out; }
+
+/* Actions Styles
+  =========================================================================== */
+.button, .file-custom .file-custom--button, button, input[type='submit'], input[type='reset'] {
+  background-color: #3F70C9;
+  color: #FFFFFF;
+  -webkit-font-smoothing: auto;
+  font-weight: 400;
+  margin: 0.05rem 0.25rem;
+  padding: 0.75rem 1rem;
+  text-align: center; }
+  .button:hover, .file-custom .file-custom--button:hover, .button:focus, .file-custom .file-custom--button:focus, button:hover, button:focus, input[type='submit']:hover, input[type='submit']:focus, input[type='reset']:hover, input[type='reset']:focus {
+    background-color: #2f59a6;
+    color: #FFFFFF; }
+  .button:active, .file-custom .file-custom--button:active, button:active, input[type='submit']:active, input[type='reset']:active {
+    background-color: #294f92; }
+  .button:not(.button--transparent) .dashing-icon:before, .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before, .button:not(.button--transparent) i.dashing-tooltip:before, .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+  .button:not(.button--transparent) i.dashing-clippy:before,
+  .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button:not(.button--transparent) .button--navigation:before, .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before, button:not(.button--transparent) .dashing-icon:before, button:not(.button--transparent) i.dashing-tooltip:before,
+  button:not(.button--transparent) i.dashing-clippy:before, button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button:not(.button--transparent) .button--navigation:before, input[type='submit']:not(.button--transparent) .dashing-icon:before, input[type='submit']:not(.button--transparent) i.dashing-tooltip:before,
+  input[type='submit']:not(.button--transparent) i.dashing-clippy:before, input[type='submit']:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit']:not(.button--transparent) .button--navigation:before, input[type='reset']:not(.button--transparent) .dashing-icon:before, input[type='reset']:not(.button--transparent) i.dashing-tooltip:before,
+  input[type='reset']:not(.button--transparent) i.dashing-clippy:before, input[type='reset']:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset']:not(.button--transparent) .button--navigation:before {
+    color: #FFFFFF; }
+  @media all and (min-width: 40em) {
+    .button, .file-custom .file-custom--button, button, input[type='submit'], input[type='reset'] {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      padding-top: 0.45rem; } }
+  .button[disabled], .file-custom [disabled].file-custom--button, .button.disabled, .file-custom .disabled.file-custom--button, .button.button--disabled, .file-custom .button--disabled.file-custom--button, button[disabled], button.disabled, button.button--disabled, input[type='submit'][disabled], input[type='submit'].disabled, input[type='submit'].button--disabled, input[type='reset'][disabled], input[type='reset'].disabled, input[type='reset'].button--disabled {
+    cursor: default;
+    opacity: 0.4;
+    pointer-events: none; }
+  .button.button-block, .file-custom .button-block.file-custom--button, button.button-block, input[type='submit'].button-block, input[type='reset'].button-block {
+    display: block !important;
+    width: 100%; }
+  .button.button--large, .file-custom .button--large.file-custom--button, button.button--large, input[type='submit'].button--large, input[type='reset'].button--large {
+    font-size: 1.25rem !important;
+    padding: 0.6rem 1.2rem; }
+  .button.button--small, .file-custom .button--small.file-custom--button, .file-custom .app-menu .app-context .app-title .file-custom--button.button--navigation, .app-menu .app-context .app-title .file-custom .file-custom--button.button--navigation, .app-menu .app-context .app-title .button.button--navigation, button.button--small, .app-menu .app-context .app-title button.button--navigation, input[type='submit'].button--small, .app-menu .app-context .app-title input[type='submit'].button--navigation, input[type='reset'].button--small, .app-menu .app-context .app-title input[type='reset'].button--navigation {
+    font-size: 0.8rem !important;
+    padding: 0.4rem 0.75rem; }
+  .button.button--primary, .file-custom .button--primary.file-custom--button, button.button--primary, input[type='submit'].button--primary, input[type='reset'].button--primary {
+    background-color: #3F70C9;
+    color: #FFFFFF; }
+    .button.button--primary:hover, .file-custom .button--primary.file-custom--button:hover, .button.button--primary:focus, .file-custom .button--primary.file-custom--button:focus, button.button--primary:hover, button.button--primary:focus, input[type='submit'].button--primary:hover, input[type='submit'].button--primary:focus, input[type='reset'].button--primary:hover, input[type='reset'].button--primary:focus {
+      background-color: #2f59a6;
+      color: #FFFFFF; }
+    .button.button--primary:active, .file-custom .button--primary.file-custom--button:active, button.button--primary:active, input[type='submit'].button--primary:active, input[type='reset'].button--primary:active {
+      background-color: #294f92; }
+    .button.button--primary:not(.button--transparent) .dashing-icon:before, .file-custom .button--primary.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--primary:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--primary.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--primary:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--primary.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--primary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--primary:not(.button--transparent) .button--navigation:before, .file-custom .button--primary.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--primary.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--primary:not(.button--transparent) .dashing-icon:before, button.button--primary:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--primary:not(.button--transparent) i.dashing-clippy:before, button.button--primary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--primary:not(.button--transparent) .button--navigation:before, input[type='submit'].button--primary:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--primary:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--primary:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--primary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--primary:not(.button--transparent) .button--navigation:before, input[type='reset'].button--primary:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--primary:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--primary:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--primary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--primary:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button.button--gray, .file-custom .button--gray.file-custom--button, .button.button--grey, .file-custom .button--grey.file-custom--button, .button.button--secondary, .file-custom .button--secondary.file-custom--button, button.button--gray, button.button--grey, button.button--secondary, input[type='submit'].button--gray, input[type='submit'].button--grey, input[type='submit'].button--secondary, input[type='reset'].button--gray, input[type='reset'].button--grey, input[type='reset'].button--secondary {
+    background-color: #D4D4D4;
+    color: #222222; }
+    .button.button--gray:hover, .file-custom .button--gray.file-custom--button:hover, .button.button--gray:focus, .file-custom .button--gray.file-custom--button:focus, .button.button--grey:hover, .file-custom .button--grey.file-custom--button:hover, .button.button--grey:focus, .file-custom .button--grey.file-custom--button:focus, .button.button--secondary:hover, .file-custom .button--secondary.file-custom--button:hover, .button.button--secondary:focus, .file-custom .button--secondary.file-custom--button:focus, button.button--gray:hover, button.button--gray:focus, button.button--grey:hover, button.button--grey:focus, button.button--secondary:hover, button.button--secondary:focus, input[type='submit'].button--gray:hover, input[type='submit'].button--gray:focus, input[type='submit'].button--grey:hover, input[type='submit'].button--grey:focus, input[type='submit'].button--secondary:hover, input[type='submit'].button--secondary:focus, input[type='reset'].button--gray:hover, input[type='reset'].button--gray:focus, input[type='reset'].button--grey:hover, input[type='reset'].button--grey:focus, input[type='reset'].button--secondary:hover, input[type='reset'].button--secondary:focus {
+      background-color: #bbbbbb;
+      color: #222222; }
+    .button.button--gray:active, .file-custom .button--gray.file-custom--button:active, .button.button--grey:active, .file-custom .button--grey.file-custom--button:active, .button.button--secondary:active, .file-custom .button--secondary.file-custom--button:active, button.button--gray:active, button.button--grey:active, button.button--secondary:active, input[type='submit'].button--gray:active, input[type='submit'].button--grey:active, input[type='submit'].button--secondary:active, input[type='reset'].button--gray:active, input[type='reset'].button--grey:active, input[type='reset'].button--secondary:active {
+      background-color: #aeaeae; }
+    .button.button--gray:not(.button--transparent) .dashing-icon:before, .file-custom .button--gray.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--gray:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--gray.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--gray:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--gray.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--gray:not(.button--transparent) .button--navigation:before, .file-custom .button--gray.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--gray.file-custom--button:not(.button--transparent) .button--navigation:before, .button.button--grey:not(.button--transparent) .dashing-icon:before, .file-custom .button--grey.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--grey:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--grey.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--grey:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--grey.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--grey:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--grey:not(.button--transparent) .button--navigation:before, .file-custom .button--grey.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--grey.file-custom--button:not(.button--transparent) .button--navigation:before, .button.button--secondary:not(.button--transparent) .dashing-icon:before, .file-custom .button--secondary.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--secondary:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--secondary.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--secondary:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--secondary.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--secondary:not(.button--transparent) .button--navigation:before, .file-custom .button--secondary.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--secondary.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--gray:not(.button--transparent) .dashing-icon:before, button.button--gray:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--gray:not(.button--transparent) i.dashing-clippy:before, button.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--gray:not(.button--transparent) .button--navigation:before, button.button--grey:not(.button--transparent) .dashing-icon:before, button.button--grey:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--grey:not(.button--transparent) i.dashing-clippy:before, button.button--grey:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--grey:not(.button--transparent) .button--navigation:before, button.button--secondary:not(.button--transparent) .dashing-icon:before, button.button--secondary:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--secondary:not(.button--transparent) i.dashing-clippy:before, button.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--secondary:not(.button--transparent) .button--navigation:before, input[type='submit'].button--gray:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--gray:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--gray:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--gray:not(.button--transparent) .button--navigation:before, input[type='submit'].button--grey:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--grey:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--grey:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--grey:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--grey:not(.button--transparent) .button--navigation:before, input[type='submit'].button--secondary:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--secondary:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--secondary:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--secondary:not(.button--transparent) .button--navigation:before, input[type='reset'].button--gray:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--gray:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--gray:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--gray:not(.button--transparent) .button--navigation:before, input[type='reset'].button--grey:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--grey:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--grey:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--grey:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--grey:not(.button--transparent) .button--navigation:before, input[type='reset'].button--secondary:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--secondary:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--secondary:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--secondary:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+    .button.button--gray .dashing-icon:before, .file-custom .button--gray.file-custom--button .dashing-icon:before, .button.button--gray i.dashing-tooltip:before, .file-custom .button--gray.file-custom--button i.dashing-tooltip:before,
+    .button.button--gray i.dashing-clippy:before,
+    .file-custom .button--gray.file-custom--button i.dashing-clippy:before, .button.button--gray .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--gray .button--navigation:before, .file-custom .button--gray.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--gray.file-custom--button .button--navigation:before, .button.button--grey .dashing-icon:before, .file-custom .button--grey.file-custom--button .dashing-icon:before, .button.button--grey i.dashing-tooltip:before, .file-custom .button--grey.file-custom--button i.dashing-tooltip:before,
+    .button.button--grey i.dashing-clippy:before,
+    .file-custom .button--grey.file-custom--button i.dashing-clippy:before, .button.button--grey .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--grey .button--navigation:before, .file-custom .button--grey.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--grey.file-custom--button .button--navigation:before, .button.button--secondary .dashing-icon:before, .file-custom .button--secondary.file-custom--button .dashing-icon:before, .button.button--secondary i.dashing-tooltip:before, .file-custom .button--secondary.file-custom--button i.dashing-tooltip:before,
+    .button.button--secondary i.dashing-clippy:before,
+    .file-custom .button--secondary.file-custom--button i.dashing-clippy:before, .button.button--secondary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--secondary .button--navigation:before, .file-custom .button--secondary.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--secondary.file-custom--button .button--navigation:before, button.button--gray .dashing-icon:before, button.button--gray i.dashing-tooltip:before,
+    button.button--gray i.dashing-clippy:before, button.button--gray .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--gray .button--navigation:before, button.button--grey .dashing-icon:before, button.button--grey i.dashing-tooltip:before,
+    button.button--grey i.dashing-clippy:before, button.button--grey .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--grey .button--navigation:before, button.button--secondary .dashing-icon:before, button.button--secondary i.dashing-tooltip:before,
+    button.button--secondary i.dashing-clippy:before, button.button--secondary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--secondary .button--navigation:before, input[type='submit'].button--gray .dashing-icon:before, input[type='submit'].button--gray i.dashing-tooltip:before,
+    input[type='submit'].button--gray i.dashing-clippy:before, input[type='submit'].button--gray .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--gray .button--navigation:before, input[type='submit'].button--grey .dashing-icon:before, input[type='submit'].button--grey i.dashing-tooltip:before,
+    input[type='submit'].button--grey i.dashing-clippy:before, input[type='submit'].button--grey .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--grey .button--navigation:before, input[type='submit'].button--secondary .dashing-icon:before, input[type='submit'].button--secondary i.dashing-tooltip:before,
+    input[type='submit'].button--secondary i.dashing-clippy:before, input[type='submit'].button--secondary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--secondary .button--navigation:before, input[type='reset'].button--gray .dashing-icon:before, input[type='reset'].button--gray i.dashing-tooltip:before,
+    input[type='reset'].button--gray i.dashing-clippy:before, input[type='reset'].button--gray .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--gray .button--navigation:before, input[type='reset'].button--grey .dashing-icon:before, input[type='reset'].button--grey i.dashing-tooltip:before,
+    input[type='reset'].button--grey i.dashing-clippy:before, input[type='reset'].button--grey .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--grey .button--navigation:before, input[type='reset'].button--secondary .dashing-icon:before, input[type='reset'].button--secondary i.dashing-tooltip:before,
+    input[type='reset'].button--secondary i.dashing-clippy:before, input[type='reset'].button--secondary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--secondary .button--navigation:before {
+      color: #555555 !important; }
+  .button.button--blue, .file-custom .button--blue.file-custom--button, button.button--blue, input[type='submit'].button--blue, input[type='reset'].button--blue {
+    background-color: #3F70C9;
+    color: #FFFFFF; }
+    .button.button--blue:hover, .file-custom .button--blue.file-custom--button:hover, .button.button--blue:focus, .file-custom .button--blue.file-custom--button:focus, button.button--blue:hover, button.button--blue:focus, input[type='submit'].button--blue:hover, input[type='submit'].button--blue:focus, input[type='reset'].button--blue:hover, input[type='reset'].button--blue:focus {
+      background-color: #2f59a6;
+      color: #FFFFFF; }
+    .button.button--blue:active, .file-custom .button--blue.file-custom--button:active, button.button--blue:active, input[type='submit'].button--blue:active, input[type='reset'].button--blue:active {
+      background-color: #294f92; }
+    .button.button--blue:not(.button--transparent) .dashing-icon:before, .file-custom .button--blue.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--blue:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--blue.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--blue:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--blue.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--blue:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--blue:not(.button--transparent) .button--navigation:before, .file-custom .button--blue.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--blue.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--blue:not(.button--transparent) .dashing-icon:before, button.button--blue:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--blue:not(.button--transparent) i.dashing-clippy:before, button.button--blue:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--blue:not(.button--transparent) .button--navigation:before, input[type='submit'].button--blue:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--blue:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--blue:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--blue:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--blue:not(.button--transparent) .button--navigation:before, input[type='reset'].button--blue:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--blue:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--blue:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--blue:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--blue:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button.button--green, .file-custom .button--green.file-custom--button, button.button--green, input[type='submit'].button--green, input[type='reset'].button--green {
+    background-color: #09AA66;
+    color: #FFFFFF; }
+    .button.button--green:hover, .file-custom .button--green.file-custom--button:hover, .button.button--green:focus, .file-custom .button--green.file-custom--button:focus, button.button--green:hover, button.button--green:focus, input[type='submit'].button--green:hover, input[type='submit'].button--green:focus, input[type='reset'].button--green:hover, input[type='reset'].button--green:focus {
+      background-color: #067a49;
+      color: #FFFFFF; }
+    .button.button--green:active, .file-custom .button--green.file-custom--button:active, button.button--green:active, input[type='submit'].button--green:active, input[type='reset'].button--green:active {
+      background-color: #05613a; }
+    .button.button--green:not(.button--transparent) .dashing-icon:before, .file-custom .button--green.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--green:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--green.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--green:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--green.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--green:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--green:not(.button--transparent) .button--navigation:before, .file-custom .button--green.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--green.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--green:not(.button--transparent) .dashing-icon:before, button.button--green:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--green:not(.button--transparent) i.dashing-clippy:before, button.button--green:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--green:not(.button--transparent) .button--navigation:before, input[type='submit'].button--green:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--green:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--green:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--green:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--green:not(.button--transparent) .button--navigation:before, input[type='reset'].button--green:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--green:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--green:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--green:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--green:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button.button--orange, .file-custom .button--orange.file-custom--button, button.button--orange, input[type='submit'].button--orange, input[type='reset'].button--orange {
+    background-color: #FFA11F;
+    color: #000000; }
+    .button.button--orange:hover, .file-custom .button--orange.file-custom--button:hover, .button.button--orange:focus, .file-custom .button--orange.file-custom--button:focus, button.button--orange:hover, button.button--orange:focus, input[type='submit'].button--orange:hover, input[type='submit'].button--orange:focus, input[type='reset'].button--orange:hover, input[type='reset'].button--orange:focus {
+      background-color: #eb8800;
+      color: #000000; }
+    .button.button--orange:active, .file-custom .button--orange.file-custom--button:active, button.button--orange:active, input[type='submit'].button--orange:active, input[type='reset'].button--orange:active {
+      background-color: #d27a00; }
+    .button.button--orange:not(.button--transparent) .dashing-icon:before, .file-custom .button--orange.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--orange:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--orange.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--orange:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--orange.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--orange:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--orange:not(.button--transparent) .button--navigation:before, .file-custom .button--orange.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--orange.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--orange:not(.button--transparent) .dashing-icon:before, button.button--orange:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--orange:not(.button--transparent) i.dashing-clippy:before, button.button--orange:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--orange:not(.button--transparent) .button--navigation:before, input[type='submit'].button--orange:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--orange:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--orange:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--orange:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--orange:not(.button--transparent) .button--navigation:before, input[type='reset'].button--orange:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--orange:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--orange:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--orange:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--orange:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button.button--purple, .file-custom .button--purple.file-custom--button, button.button--purple, input[type='submit'].button--purple, input[type='reset'].button--purple {
+    background-color: #9F65AE;
+    color: #FFFFFF; }
+    .button.button--purple:hover, .file-custom .button--purple.file-custom--button:hover, .button.button--purple:focus, .file-custom .button--purple.file-custom--button:focus, button.button--purple:hover, button.button--purple:focus, input[type='submit'].button--purple:hover, input[type='submit'].button--purple:focus, input[type='reset'].button--purple:hover, input[type='reset'].button--purple:focus {
+      background-color: #844d93;
+      color: #FFFFFF; }
+    .button.button--purple:active, .file-custom .button--purple.file-custom--button:active, button.button--purple:active, input[type='submit'].button--purple:active, input[type='reset'].button--purple:active {
+      background-color: #754482; }
+    .button.button--purple:not(.button--transparent) .dashing-icon:before, .file-custom .button--purple.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--purple:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--purple.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--purple:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--purple.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--purple:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--purple:not(.button--transparent) .button--navigation:before, .file-custom .button--purple.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--purple.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--purple:not(.button--transparent) .dashing-icon:before, button.button--purple:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--purple:not(.button--transparent) i.dashing-clippy:before, button.button--purple:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--purple:not(.button--transparent) .button--navigation:before, input[type='submit'].button--purple:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--purple:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--purple:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--purple:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--purple:not(.button--transparent) .button--navigation:before, input[type='reset'].button--purple:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--purple:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--purple:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--purple:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--purple:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button.button--red, .file-custom .button--red.file-custom--button, button.button--red, input[type='submit'].button--red, input[type='reset'].button--red {
+    background-color: #DA3D30;
+    color: #FFFFFF; }
+    .button.button--red:hover, .file-custom .button--red.file-custom--button:hover, .button.button--red:focus, .file-custom .button--red.file-custom--button:focus, button.button--red:hover, button.button--red:focus, input[type='submit'].button--red:hover, input[type='submit'].button--red:focus, input[type='reset'].button--red:hover, input[type='reset'].button--red:focus {
+      background-color: #b62c21;
+      color: #FFFFFF; }
+    .button.button--red:active, .file-custom .button--red.file-custom--button:active, button.button--red:active, input[type='submit'].button--red:active, input[type='reset'].button--red:active {
+      background-color: #a1271d; }
+    .button.button--red:not(.button--transparent) .dashing-icon:before, .file-custom .button--red.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--red:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--red.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--red:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--red.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--red:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--red:not(.button--transparent) .button--navigation:before, .file-custom .button--red.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--red.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--red:not(.button--transparent) .dashing-icon:before, button.button--red:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--red:not(.button--transparent) i.dashing-clippy:before, button.button--red:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--red:not(.button--transparent) .button--navigation:before, input[type='submit'].button--red:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--red:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--red:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--red:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--red:not(.button--transparent) .button--navigation:before, input[type='reset'].button--red:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--red:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--red:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--red:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--red:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button.button--white, .file-custom .button--white.file-custom--button, button.button--white, input[type='submit'].button--white, input[type='reset'].button--white {
+    background-color: #FFFFFF;
+    color: #3B3B3B; }
+    .button.button--white:hover, .file-custom .button--white.file-custom--button:hover, .button.button--white:focus, .file-custom .button--white.file-custom--button:focus, button.button--white:hover, button.button--white:focus, input[type='submit'].button--white:hover, input[type='submit'].button--white:focus, input[type='reset'].button--white:hover, input[type='reset'].button--white:focus {
+      background-color: #e6e6e6;
+      color: #3B3B3B; }
+    .button.button--white:active, .file-custom .button--white.file-custom--button:active, button.button--white:active, input[type='submit'].button--white:active, input[type='reset'].button--white:active {
+      background-color: #d9d9d9; }
+    .button.button--white:not(.button--transparent) .dashing-icon:before, .file-custom .button--white.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--white:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--white.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--white:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--white.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--white:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--white:not(.button--transparent) .button--navigation:before, .file-custom .button--white.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--white.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--white:not(.button--transparent) .dashing-icon:before, button.button--white:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--white:not(.button--transparent) i.dashing-clippy:before, button.button--white:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--white:not(.button--transparent) .button--navigation:before, input[type='submit'].button--white:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--white:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--white:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--white:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--white:not(.button--transparent) .button--navigation:before, input[type='reset'].button--white:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--white:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--white:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--white:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--white:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button.button--black, .file-custom .button--black.file-custom--button, button.button--black, input[type='submit'].button--black, input[type='reset'].button--black {
+    background-color: #000000;
+    color: #FFFFFF; }
+    .button.button--black:hover, .file-custom .button--black.file-custom--button:hover, .button.button--black:focus, .file-custom .button--black.file-custom--button:focus, button.button--black:hover, button.button--black:focus, input[type='submit'].button--black:hover, input[type='submit'].button--black:focus, input[type='reset'].button--black:hover, input[type='reset'].button--black:focus {
+      background-color: black;
+      color: #FFFFFF; }
+    .button.button--black:active, .file-custom .button--black.file-custom--button:active, button.button--black:active, input[type='submit'].button--black:active, input[type='reset'].button--black:active {
+      background-color: black; }
+    .button.button--black:not(.button--transparent) .dashing-icon:before, .file-custom .button--black.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--black:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--black.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--black:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--black.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--black:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--black:not(.button--transparent) .button--navigation:before, .file-custom .button--black.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--black.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--black:not(.button--transparent) .dashing-icon:before, button.button--black:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--black:not(.button--transparent) i.dashing-clippy:before, button.button--black:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--black:not(.button--transparent) .button--navigation:before, input[type='submit'].button--black:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--black:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--black:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--black:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--black:not(.button--transparent) .button--navigation:before, input[type='reset'].button--black:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--black:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--black:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--black:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--black:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button.button--transparent, .file-custom .button--transparent.file-custom--button, button.button--transparent, input[type='submit'].button--transparent, input[type='reset'].button--transparent {
+    background-color: rgba(255, 255, 255, 0);
+    color: #3F70C9;
+    background-color: rgba(255, 255, 255, 0);
+    color: #3F70C9; }
+    .button.button--transparent:hover, .file-custom .button--transparent.file-custom--button:hover, .button.button--transparent:focus, .file-custom .button--transparent.file-custom--button:focus, button.button--transparent:hover, button.button--transparent:focus, input[type='submit'].button--transparent:hover, input[type='submit'].button--transparent:focus, input[type='reset'].button--transparent:hover, input[type='reset'].button--transparent:focus {
+      background-color: rgba(230, 230, 230, 0);
+      color: #3F70C9; }
+    .button.button--transparent:active, .file-custom .button--transparent.file-custom--button:active, button.button--transparent:active, input[type='submit'].button--transparent:active, input[type='reset'].button--transparent:active {
+      background-color: rgba(217, 217, 217, 0); }
+    .button.button--transparent:not(.button--transparent) .dashing-icon:before, .file-custom .button--transparent.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--transparent:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--transparent.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button.button--transparent:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button--transparent.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent:not(.button--transparent) .button--navigation:before, .file-custom .button--transparent.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--transparent:not(.button--transparent) .dashing-icon:before, button.button--transparent:not(.button--transparent) i.dashing-tooltip:before,
+    button.button--transparent:not(.button--transparent) i.dashing-clippy:before, button.button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent:not(.button--transparent) .button--navigation:before, input[type='submit'].button--transparent:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--transparent:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='submit'].button--transparent:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent:not(.button--transparent) .button--navigation:before, input[type='reset'].button--transparent:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--transparent:not(.button--transparent) i.dashing-tooltip:before,
+    input[type='reset'].button--transparent:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+    .button.button--transparent:hover, .file-custom .button--transparent.file-custom--button:hover, .button.button--transparent:focus, .file-custom .button--transparent.file-custom--button:focus, button.button--transparent:hover, button.button--transparent:focus, input[type='submit'].button--transparent:hover, input[type='submit'].button--transparent:focus, input[type='reset'].button--transparent:hover, input[type='reset'].button--transparent:focus {
+      opacity: .6; }
+    .button.button--transparent:active, .file-custom .button--transparent.file-custom--button:active, button.button--transparent:active, input[type='submit'].button--transparent:active, input[type='reset'].button--transparent:active {
+      opacity: .9; }
+    .button.button--transparent:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+    .button.button--transparent:not(.button--icon) i.dashing-clippy:before,
+    .file-custom .button--transparent.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent:not(.button--icon) .dashing-icon:before, button.button--transparent:not(.button--icon) i.dashing-tooltip:before,
+    button.button--transparent:not(.button--icon) i.dashing-clippy:before, button.button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent:not(.button--icon) i.dashing-tooltip:before,
+    input[type='submit'].button--transparent:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent:not(.button--icon) i.dashing-tooltip:before,
+    input[type='reset'].button--transparent:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent:not(.button--icon) .button--navigation:before {
+      color: #3F70C9; }
+    .button.button--transparent:not(.button--icon), .file-custom .button--transparent.file-custom--button:not(.button--icon), button.button--transparent:not(.button--icon), input[type='submit'].button--transparent:not(.button--icon), input[type='reset'].button--transparent:not(.button--icon) {
+      padding-left: 0;
+      padding-right: 0; }
+    .button.button--transparent.button--primary, .file-custom .button--transparent.button--primary.file-custom--button, button.button--transparent.button--primary, input[type='submit'].button--transparent.button--primary, input[type='reset'].button--transparent.button--primary {
+      background-color: rgba(255, 255, 255, 0);
+      color: #3F70C9; }
+      .button.button--transparent.button--primary:hover, .file-custom .button--transparent.button--primary.file-custom--button:hover, .button.button--transparent.button--primary:focus, .file-custom .button--transparent.button--primary.file-custom--button:focus, button.button--transparent.button--primary:hover, button.button--transparent.button--primary:focus, input[type='submit'].button--transparent.button--primary:hover, input[type='submit'].button--transparent.button--primary:focus, input[type='reset'].button--transparent.button--primary:hover, input[type='reset'].button--transparent.button--primary:focus {
+        opacity: .6; }
+      .button.button--transparent.button--primary:active, .file-custom .button--transparent.button--primary.file-custom--button:active, button.button--transparent.button--primary:active, input[type='submit'].button--transparent.button--primary:active, input[type='reset'].button--transparent.button--primary:active {
+        opacity: .9; }
+      .button.button--transparent.button--primary:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--primary:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--primary:not(.button--icon) .dashing-icon:before, button.button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--primary:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--primary:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--primary:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--primary:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--primary:not(.button--icon) .button--navigation:before {
+        color: #3F70C9; }
+    .button.button--transparent.button--secondary, .file-custom .button--transparent.button--secondary.file-custom--button, button.button--transparent.button--secondary, input[type='submit'].button--transparent.button--secondary, input[type='reset'].button--transparent.button--secondary {
+      background-color: rgba(255, 255, 255, 0);
+      color: #6E6E6E; }
+      .button.button--transparent.button--secondary:hover, .file-custom .button--transparent.button--secondary.file-custom--button:hover, .button.button--transparent.button--secondary:focus, .file-custom .button--transparent.button--secondary.file-custom--button:focus, button.button--transparent.button--secondary:hover, button.button--transparent.button--secondary:focus, input[type='submit'].button--transparent.button--secondary:hover, input[type='submit'].button--transparent.button--secondary:focus, input[type='reset'].button--transparent.button--secondary:hover, input[type='reset'].button--transparent.button--secondary:focus {
+        opacity: .6; }
+      .button.button--transparent.button--secondary:active, .file-custom .button--transparent.button--secondary.file-custom--button:active, button.button--transparent.button--secondary:active, input[type='submit'].button--transparent.button--secondary:active, input[type='reset'].button--transparent.button--secondary:active {
+        opacity: .9; }
+      .button.button--transparent.button--secondary:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--secondary:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--secondary:not(.button--icon) .dashing-icon:before, button.button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--secondary:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--secondary:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--secondary:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--secondary:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--secondary:not(.button--icon) .button--navigation:before {
+        color: #6E6E6E; }
+    .button.button--transparent.button--blue, .file-custom .button--transparent.button--blue.file-custom--button, button.button--transparent.button--blue, input[type='submit'].button--transparent.button--blue, input[type='reset'].button--transparent.button--blue {
+      background-color: rgba(255, 255, 255, 0);
+      color: #3F70C9; }
+      .button.button--transparent.button--blue:hover, .file-custom .button--transparent.button--blue.file-custom--button:hover, .button.button--transparent.button--blue:focus, .file-custom .button--transparent.button--blue.file-custom--button:focus, button.button--transparent.button--blue:hover, button.button--transparent.button--blue:focus, input[type='submit'].button--transparent.button--blue:hover, input[type='submit'].button--transparent.button--blue:focus, input[type='reset'].button--transparent.button--blue:hover, input[type='reset'].button--transparent.button--blue:focus {
+        opacity: .6; }
+      .button.button--transparent.button--blue:active, .file-custom .button--transparent.button--blue.file-custom--button:active, button.button--transparent.button--blue:active, input[type='submit'].button--transparent.button--blue:active, input[type='reset'].button--transparent.button--blue:active {
+        opacity: .9; }
+      .button.button--transparent.button--blue:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--blue:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--blue:not(.button--icon) .dashing-icon:before, button.button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--blue:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--blue:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--blue:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--blue:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--blue:not(.button--icon) .button--navigation:before {
+        color: #3F70C9; }
+    .button.button--transparent.button--gray, .file-custom .button--transparent.button--gray.file-custom--button, .button.button--transparent.button--grey, .file-custom .button--transparent.button--grey.file-custom--button, button.button--transparent.button--gray, button.button--transparent.button--grey, input[type='submit'].button--transparent.button--gray, input[type='submit'].button--transparent.button--grey, input[type='reset'].button--transparent.button--gray, input[type='reset'].button--transparent.button--grey {
+      background-color: rgba(255, 255, 255, 0);
+      color: #6E6E6E; }
+      .button.button--transparent.button--gray:hover, .file-custom .button--transparent.button--gray.file-custom--button:hover, .button.button--transparent.button--gray:focus, .file-custom .button--transparent.button--gray.file-custom--button:focus, .button.button--transparent.button--grey:hover, .file-custom .button--transparent.button--grey.file-custom--button:hover, .button.button--transparent.button--grey:focus, .file-custom .button--transparent.button--grey.file-custom--button:focus, button.button--transparent.button--gray:hover, button.button--transparent.button--gray:focus, button.button--transparent.button--grey:hover, button.button--transparent.button--grey:focus, input[type='submit'].button--transparent.button--gray:hover, input[type='submit'].button--transparent.button--gray:focus, input[type='submit'].button--transparent.button--grey:hover, input[type='submit'].button--transparent.button--grey:focus, input[type='reset'].button--transparent.button--gray:hover, input[type='reset'].button--transparent.button--gray:focus, input[type='reset'].button--transparent.button--grey:hover, input[type='reset'].button--transparent.button--grey:focus {
+        opacity: .6; }
+      .button.button--transparent.button--gray:active, .file-custom .button--transparent.button--gray.file-custom--button:active, .button.button--transparent.button--grey:active, .file-custom .button--transparent.button--grey.file-custom--button:active, button.button--transparent.button--gray:active, button.button--transparent.button--grey:active, input[type='submit'].button--transparent.button--gray:active, input[type='submit'].button--transparent.button--grey:active, input[type='reset'].button--transparent.button--gray:active, input[type='reset'].button--transparent.button--grey:active {
+        opacity: .9; }
+      .button.button--transparent.button--gray:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--gray:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--gray:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--grey:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--grey:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--grey:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--grey:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--grey:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--gray:not(.button--icon) .dashing-icon:before, button.button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--gray:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--gray:not(.button--icon) .button--navigation:before, button.button--transparent.button--grey:not(.button--icon) .dashing-icon:before, button.button--transparent.button--grey:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--grey:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--grey:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--grey:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--gray:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--gray:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--gray:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--grey:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--grey:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--grey:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--grey:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--grey:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--gray:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--gray:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--gray:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--grey:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--grey:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--grey:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--grey:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--grey:not(.button--icon) .button--navigation:before {
+        color: #6E6E6E; }
+    .button.button--transparent.button--green, .file-custom .button--transparent.button--green.file-custom--button, button.button--transparent.button--green, input[type='submit'].button--transparent.button--green, input[type='reset'].button--transparent.button--green {
+      background-color: rgba(255, 255, 255, 0);
+      color: #09AA66; }
+      .button.button--transparent.button--green:hover, .file-custom .button--transparent.button--green.file-custom--button:hover, .button.button--transparent.button--green:focus, .file-custom .button--transparent.button--green.file-custom--button:focus, button.button--transparent.button--green:hover, button.button--transparent.button--green:focus, input[type='submit'].button--transparent.button--green:hover, input[type='submit'].button--transparent.button--green:focus, input[type='reset'].button--transparent.button--green:hover, input[type='reset'].button--transparent.button--green:focus {
+        opacity: .6; }
+      .button.button--transparent.button--green:active, .file-custom .button--transparent.button--green.file-custom--button:active, button.button--transparent.button--green:active, input[type='submit'].button--transparent.button--green:active, input[type='reset'].button--transparent.button--green:active {
+        opacity: .9; }
+      .button.button--transparent.button--green:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--green:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--green:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--green:not(.button--icon) .dashing-icon:before, button.button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--green:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--green:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--green:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--green:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--green:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--green:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--green:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--green:not(.button--icon) .button--navigation:before {
+        color: #09AA66; }
+    .button.button--transparent.button--red, .file-custom .button--transparent.button--red.file-custom--button, button.button--transparent.button--red, input[type='submit'].button--transparent.button--red, input[type='reset'].button--transparent.button--red {
+      background-color: rgba(255, 255, 255, 0);
+      color: #DA3D30; }
+      .button.button--transparent.button--red:hover, .file-custom .button--transparent.button--red.file-custom--button:hover, .button.button--transparent.button--red:focus, .file-custom .button--transparent.button--red.file-custom--button:focus, button.button--transparent.button--red:hover, button.button--transparent.button--red:focus, input[type='submit'].button--transparent.button--red:hover, input[type='submit'].button--transparent.button--red:focus, input[type='reset'].button--transparent.button--red:hover, input[type='reset'].button--transparent.button--red:focus {
+        opacity: .6; }
+      .button.button--transparent.button--red:active, .file-custom .button--transparent.button--red.file-custom--button:active, button.button--transparent.button--red:active, input[type='submit'].button--transparent.button--red:active, input[type='reset'].button--transparent.button--red:active {
+        opacity: .9; }
+      .button.button--transparent.button--red:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--red:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--red:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--red:not(.button--icon) .dashing-icon:before, button.button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--red:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--red:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--red:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--red:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--red:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--red:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--red:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--red:not(.button--icon) .button--navigation:before {
+        color: #DA3D30; }
+    .button.button--transparent.button--orange, .file-custom .button--transparent.button--orange.file-custom--button, button.button--transparent.button--orange, input[type='submit'].button--transparent.button--orange, input[type='reset'].button--transparent.button--orange {
+      background-color: rgba(255, 255, 255, 0);
+      color: #FFA11F; }
+      .button.button--transparent.button--orange:hover, .file-custom .button--transparent.button--orange.file-custom--button:hover, .button.button--transparent.button--orange:focus, .file-custom .button--transparent.button--orange.file-custom--button:focus, button.button--transparent.button--orange:hover, button.button--transparent.button--orange:focus, input[type='submit'].button--transparent.button--orange:hover, input[type='submit'].button--transparent.button--orange:focus, input[type='reset'].button--transparent.button--orange:hover, input[type='reset'].button--transparent.button--orange:focus {
+        opacity: .6; }
+      .button.button--transparent.button--orange:active, .file-custom .button--transparent.button--orange.file-custom--button:active, button.button--transparent.button--orange:active, input[type='submit'].button--transparent.button--orange:active, input[type='reset'].button--transparent.button--orange:active {
+        opacity: .9; }
+      .button.button--transparent.button--orange:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--orange:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--orange:not(.button--icon) .dashing-icon:before, button.button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--orange:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--orange:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--orange:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--orange:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--orange:not(.button--icon) .button--navigation:before {
+        color: #FFA11F; }
+    .button.button--transparent.button--purple, .file-custom .button--transparent.button--purple.file-custom--button, button.button--transparent.button--purple, input[type='submit'].button--transparent.button--purple, input[type='reset'].button--transparent.button--purple {
+      background-color: rgba(255, 255, 255, 0);
+      color: #9F65AE; }
+      .button.button--transparent.button--purple:hover, .file-custom .button--transparent.button--purple.file-custom--button:hover, .button.button--transparent.button--purple:focus, .file-custom .button--transparent.button--purple.file-custom--button:focus, button.button--transparent.button--purple:hover, button.button--transparent.button--purple:focus, input[type='submit'].button--transparent.button--purple:hover, input[type='submit'].button--transparent.button--purple:focus, input[type='reset'].button--transparent.button--purple:hover, input[type='reset'].button--transparent.button--purple:focus {
+        opacity: .6; }
+      .button.button--transparent.button--purple:active, .file-custom .button--transparent.button--purple.file-custom--button:active, button.button--transparent.button--purple:active, input[type='submit'].button--transparent.button--purple:active, input[type='reset'].button--transparent.button--purple:active {
+        opacity: .9; }
+      .button.button--transparent.button--purple:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--purple:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--purple:not(.button--icon) .dashing-icon:before, button.button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--purple:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--purple:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--purple:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--purple:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--purple:not(.button--icon) .button--navigation:before {
+        color: #9F65AE; }
+    .button.button--transparent.button--white, .file-custom .button--transparent.button--white.file-custom--button, button.button--transparent.button--white, input[type='submit'].button--transparent.button--white, input[type='reset'].button--transparent.button--white {
+      background-color: rgba(255, 255, 255, 0);
+      color: #FFFFFF; }
+      .button.button--transparent.button--white:hover, .file-custom .button--transparent.button--white.file-custom--button:hover, .button.button--transparent.button--white:focus, .file-custom .button--transparent.button--white.file-custom--button:focus, button.button--transparent.button--white:hover, button.button--transparent.button--white:focus, input[type='submit'].button--transparent.button--white:hover, input[type='submit'].button--transparent.button--white:focus, input[type='reset'].button--transparent.button--white:hover, input[type='reset'].button--transparent.button--white:focus {
+        opacity: .6; }
+      .button.button--transparent.button--white:active, .file-custom .button--transparent.button--white.file-custom--button:active, button.button--transparent.button--white:active, input[type='submit'].button--transparent.button--white:active, input[type='reset'].button--transparent.button--white:active {
+        opacity: .9; }
+      .button.button--transparent.button--white:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
+      .button.button--transparent.button--white:not(.button--icon) i.dashing-clippy:before,
+      .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--white:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--white:not(.button--icon) .dashing-icon:before, button.button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before,
+      button.button--transparent.button--white:not(.button--icon) i.dashing-clippy:before, button.button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--transparent.button--white:not(.button--icon) .button--navigation:before, input[type='submit'].button--transparent.button--white:not(.button--icon) .dashing-icon:before, input[type='submit'].button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before,
+      input[type='submit'].button--transparent.button--white:not(.button--icon) i.dashing-clippy:before, input[type='submit'].button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--transparent.button--white:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent.button--white:not(.button--icon) .dashing-icon:before, input[type='reset'].button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before,
+      input[type='reset'].button--transparent.button--white:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent.button--white:not(.button--icon) .button--navigation:before {
+        color: #FFFFFF; }
+  .button.button--border, .file-custom .button--border.file-custom--button, button.button--border, input[type='submit'].button--border, input[type='reset'].button--border {
+    background-color: rgba(255, 255, 255, 0);
+    border-color: #3F70C9;
+    color: #3F70C9;
+    border: 2px solid; }
+    .button.button--border .dashing-icon:before, .file-custom .button--border.file-custom--button .dashing-icon:before, .button.button--border i.dashing-tooltip:before, .file-custom .button--border.file-custom--button i.dashing-tooltip:before,
+    .button.button--border i.dashing-clippy:before,
+    .file-custom .button--border.file-custom--button i.dashing-clippy:before, .button.button--border .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border .button--navigation:before, .file-custom .button--border.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.file-custom--button .button--navigation:before, button.button--border .dashing-icon:before, button.button--border i.dashing-tooltip:before,
+    button.button--border i.dashing-clippy:before, button.button--border .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border .button--navigation:before, input[type='submit'].button--border .dashing-icon:before, input[type='submit'].button--border i.dashing-tooltip:before,
+    input[type='submit'].button--border i.dashing-clippy:before, input[type='submit'].button--border .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border .button--navigation:before, input[type='reset'].button--border .dashing-icon:before, input[type='reset'].button--border i.dashing-tooltip:before,
+    input[type='reset'].button--border i.dashing-clippy:before, input[type='reset'].button--border .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border .button--navigation:before {
+      color: #3F70C9; }
+    .button.button--border:hover, .file-custom .button--border.file-custom--button:hover, .button.button--border:focus, .file-custom .button--border.file-custom--button:focus, button.button--border:hover, button.button--border:focus, input[type='submit'].button--border:hover, input[type='submit'].button--border:focus, input[type='reset'].button--border:hover, input[type='reset'].button--border:focus {
+      background-color: #2f59a6;
+      border-color: rgba(255, 255, 255, 0);
+      color: #FFFFFF; }
+      .button.button--border:hover .dashing-icon:before, .file-custom .button--border.file-custom--button:hover .dashing-icon:before, .button.button--border:hover i.dashing-tooltip:before, .file-custom .button--border.file-custom--button:hover i.dashing-tooltip:before,
+      .button.button--border:hover i.dashing-clippy:before,
+      .file-custom .button--border.file-custom--button:hover i.dashing-clippy:before, .button.button--border:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border:hover .button--navigation:before, .file-custom .button--border.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.file-custom--button:hover .button--navigation:before, .button.button--border:focus .dashing-icon:before, .file-custom .button--border.file-custom--button:focus .dashing-icon:before, .button.button--border:focus i.dashing-tooltip:before, .file-custom .button--border.file-custom--button:focus i.dashing-tooltip:before,
+      .button.button--border:focus i.dashing-clippy:before,
+      .file-custom .button--border.file-custom--button:focus i.dashing-clippy:before, .button.button--border:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border:focus .button--navigation:before, .file-custom .button--border.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.file-custom--button:focus .button--navigation:before, button.button--border:hover .dashing-icon:before, button.button--border:hover i.dashing-tooltip:before,
+      button.button--border:hover i.dashing-clippy:before, button.button--border:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border:hover .button--navigation:before, button.button--border:focus .dashing-icon:before, button.button--border:focus i.dashing-tooltip:before,
+      button.button--border:focus i.dashing-clippy:before, button.button--border:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border:focus .button--navigation:before, input[type='submit'].button--border:hover .dashing-icon:before, input[type='submit'].button--border:hover i.dashing-tooltip:before,
+      input[type='submit'].button--border:hover i.dashing-clippy:before, input[type='submit'].button--border:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border:hover .button--navigation:before, input[type='submit'].button--border:focus .dashing-icon:before, input[type='submit'].button--border:focus i.dashing-tooltip:before,
+      input[type='submit'].button--border:focus i.dashing-clippy:before, input[type='submit'].button--border:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border:focus .button--navigation:before, input[type='reset'].button--border:hover .dashing-icon:before, input[type='reset'].button--border:hover i.dashing-tooltip:before,
+      input[type='reset'].button--border:hover i.dashing-clippy:before, input[type='reset'].button--border:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border:hover .button--navigation:before, input[type='reset'].button--border:focus .dashing-icon:before, input[type='reset'].button--border:focus i.dashing-tooltip:before,
+      input[type='reset'].button--border:focus i.dashing-clippy:before, input[type='reset'].button--border:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border:focus .button--navigation:before {
+        color: #FFFFFF;
+        transition: all 50ms ease-in-out; }
+    .button.button--border:active, .file-custom .button--border.file-custom--button:active, button.button--border:active, input[type='submit'].button--border:active, input[type='reset'].button--border:active {
+      background-color: #294f92; }
+    @media all and (min-width: 40em) {
+      .button.button--border, .file-custom .button--border.file-custom--button, button.button--border, input[type='submit'].button--border, input[type='reset'].button--border {
+        padding-top: calc(0.45rem - 2px);
+        padding-bottom: calc(0.5rem - 2px);
+        padding-left: calc(1rem - 2px);
+        padding-right: calc(1rem - 2px); } }
+    .button.button--border.button--primary, .file-custom .button--border.button--primary.file-custom--button, button.button--border.button--primary, input[type='submit'].button--border.button--primary, input[type='reset'].button--border.button--primary {
+      background-color: rgba(255, 255, 255, 0);
+      border-color: #3F70C9;
+      color: #3F70C9; }
+      .button.button--border.button--primary .dashing-icon:before, .file-custom .button--border.button--primary.file-custom--button .dashing-icon:before, .button.button--border.button--primary i.dashing-tooltip:before, .file-custom .button--border.button--primary.file-custom--button i.dashing-tooltip:before,
+      .button.button--border.button--primary i.dashing-clippy:before,
+      .file-custom .button--border.button--primary.file-custom--button i.dashing-clippy:before, .button.button--border.button--primary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--primary .button--navigation:before, .file-custom .button--border.button--primary.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--primary.file-custom--button .button--navigation:before, button.button--border.button--primary .dashing-icon:before, button.button--border.button--primary i.dashing-tooltip:before,
+      button.button--border.button--primary i.dashing-clippy:before, button.button--border.button--primary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--primary .button--navigation:before, input[type='submit'].button--border.button--primary .dashing-icon:before, input[type='submit'].button--border.button--primary i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--primary i.dashing-clippy:before, input[type='submit'].button--border.button--primary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--primary .button--navigation:before, input[type='reset'].button--border.button--primary .dashing-icon:before, input[type='reset'].button--border.button--primary i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--primary i.dashing-clippy:before, input[type='reset'].button--border.button--primary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--primary .button--navigation:before {
+        color: #3F70C9; }
+      .button.button--border.button--primary:hover, .file-custom .button--border.button--primary.file-custom--button:hover, .button.button--border.button--primary:focus, .file-custom .button--border.button--primary.file-custom--button:focus, button.button--border.button--primary:hover, button.button--border.button--primary:focus, input[type='submit'].button--border.button--primary:hover, input[type='submit'].button--border.button--primary:focus, input[type='reset'].button--border.button--primary:hover, input[type='reset'].button--border.button--primary:focus {
+        background-color: #2f59a6;
+        border-color: rgba(255, 255, 255, 0);
+        color: #FFFFFF; }
+        .button.button--border.button--primary:hover .dashing-icon:before, .file-custom .button--border.button--primary.file-custom--button:hover .dashing-icon:before, .button.button--border.button--primary:hover i.dashing-tooltip:before, .file-custom .button--border.button--primary.file-custom--button:hover i.dashing-tooltip:before,
+        .button.button--border.button--primary:hover i.dashing-clippy:before,
+        .file-custom .button--border.button--primary.file-custom--button:hover i.dashing-clippy:before, .button.button--border.button--primary:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--primary:hover .button--navigation:before, .file-custom .button--border.button--primary.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--primary.file-custom--button:hover .button--navigation:before, .button.button--border.button--primary:focus .dashing-icon:before, .file-custom .button--border.button--primary.file-custom--button:focus .dashing-icon:before, .button.button--border.button--primary:focus i.dashing-tooltip:before, .file-custom .button--border.button--primary.file-custom--button:focus i.dashing-tooltip:before,
+        .button.button--border.button--primary:focus i.dashing-clippy:before,
+        .file-custom .button--border.button--primary.file-custom--button:focus i.dashing-clippy:before, .button.button--border.button--primary:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--primary:focus .button--navigation:before, .file-custom .button--border.button--primary.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--primary.file-custom--button:focus .button--navigation:before, button.button--border.button--primary:hover .dashing-icon:before, button.button--border.button--primary:hover i.dashing-tooltip:before,
+        button.button--border.button--primary:hover i.dashing-clippy:before, button.button--border.button--primary:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--primary:hover .button--navigation:before, button.button--border.button--primary:focus .dashing-icon:before, button.button--border.button--primary:focus i.dashing-tooltip:before,
+        button.button--border.button--primary:focus i.dashing-clippy:before, button.button--border.button--primary:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--primary:focus .button--navigation:before, input[type='submit'].button--border.button--primary:hover .dashing-icon:before, input[type='submit'].button--border.button--primary:hover i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--primary:hover i.dashing-clippy:before, input[type='submit'].button--border.button--primary:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--primary:hover .button--navigation:before, input[type='submit'].button--border.button--primary:focus .dashing-icon:before, input[type='submit'].button--border.button--primary:focus i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--primary:focus i.dashing-clippy:before, input[type='submit'].button--border.button--primary:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--primary:focus .button--navigation:before, input[type='reset'].button--border.button--primary:hover .dashing-icon:before, input[type='reset'].button--border.button--primary:hover i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--primary:hover i.dashing-clippy:before, input[type='reset'].button--border.button--primary:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--primary:hover .button--navigation:before, input[type='reset'].button--border.button--primary:focus .dashing-icon:before, input[type='reset'].button--border.button--primary:focus i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--primary:focus i.dashing-clippy:before, input[type='reset'].button--border.button--primary:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--primary:focus .button--navigation:before {
+          color: #FFFFFF;
+          transition: all 50ms ease-in-out; }
+      .button.button--border.button--primary:active, .file-custom .button--border.button--primary.file-custom--button:active, button.button--border.button--primary:active, input[type='submit'].button--border.button--primary:active, input[type='reset'].button--border.button--primary:active {
+        background-color: #294f92; }
+    .button.button--border.button--blue, .file-custom .button--border.button--blue.file-custom--button, button.button--border.button--blue, input[type='submit'].button--border.button--blue, input[type='reset'].button--border.button--blue {
+      background-color: rgba(255, 255, 255, 0);
+      border-color: #3F70C9;
+      color: #3F70C9; }
+      .button.button--border.button--blue .dashing-icon:before, .file-custom .button--border.button--blue.file-custom--button .dashing-icon:before, .button.button--border.button--blue i.dashing-tooltip:before, .file-custom .button--border.button--blue.file-custom--button i.dashing-tooltip:before,
+      .button.button--border.button--blue i.dashing-clippy:before,
+      .file-custom .button--border.button--blue.file-custom--button i.dashing-clippy:before, .button.button--border.button--blue .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--blue .button--navigation:before, .file-custom .button--border.button--blue.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--blue.file-custom--button .button--navigation:before, button.button--border.button--blue .dashing-icon:before, button.button--border.button--blue i.dashing-tooltip:before,
+      button.button--border.button--blue i.dashing-clippy:before, button.button--border.button--blue .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--blue .button--navigation:before, input[type='submit'].button--border.button--blue .dashing-icon:before, input[type='submit'].button--border.button--blue i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--blue i.dashing-clippy:before, input[type='submit'].button--border.button--blue .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--blue .button--navigation:before, input[type='reset'].button--border.button--blue .dashing-icon:before, input[type='reset'].button--border.button--blue i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--blue i.dashing-clippy:before, input[type='reset'].button--border.button--blue .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--blue .button--navigation:before {
+        color: #3F70C9; }
+      .button.button--border.button--blue:hover, .file-custom .button--border.button--blue.file-custom--button:hover, .button.button--border.button--blue:focus, .file-custom .button--border.button--blue.file-custom--button:focus, button.button--border.button--blue:hover, button.button--border.button--blue:focus, input[type='submit'].button--border.button--blue:hover, input[type='submit'].button--border.button--blue:focus, input[type='reset'].button--border.button--blue:hover, input[type='reset'].button--border.button--blue:focus {
+        background-color: #2f59a6;
+        border-color: rgba(255, 255, 255, 0);
+        color: #FFFFFF; }
+        .button.button--border.button--blue:hover .dashing-icon:before, .file-custom .button--border.button--blue.file-custom--button:hover .dashing-icon:before, .button.button--border.button--blue:hover i.dashing-tooltip:before, .file-custom .button--border.button--blue.file-custom--button:hover i.dashing-tooltip:before,
+        .button.button--border.button--blue:hover i.dashing-clippy:before,
+        .file-custom .button--border.button--blue.file-custom--button:hover i.dashing-clippy:before, .button.button--border.button--blue:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--blue:hover .button--navigation:before, .file-custom .button--border.button--blue.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--blue.file-custom--button:hover .button--navigation:before, .button.button--border.button--blue:focus .dashing-icon:before, .file-custom .button--border.button--blue.file-custom--button:focus .dashing-icon:before, .button.button--border.button--blue:focus i.dashing-tooltip:before, .file-custom .button--border.button--blue.file-custom--button:focus i.dashing-tooltip:before,
+        .button.button--border.button--blue:focus i.dashing-clippy:before,
+        .file-custom .button--border.button--blue.file-custom--button:focus i.dashing-clippy:before, .button.button--border.button--blue:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--blue:focus .button--navigation:before, .file-custom .button--border.button--blue.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--blue.file-custom--button:focus .button--navigation:before, button.button--border.button--blue:hover .dashing-icon:before, button.button--border.button--blue:hover i.dashing-tooltip:before,
+        button.button--border.button--blue:hover i.dashing-clippy:before, button.button--border.button--blue:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--blue:hover .button--navigation:before, button.button--border.button--blue:focus .dashing-icon:before, button.button--border.button--blue:focus i.dashing-tooltip:before,
+        button.button--border.button--blue:focus i.dashing-clippy:before, button.button--border.button--blue:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--blue:focus .button--navigation:before, input[type='submit'].button--border.button--blue:hover .dashing-icon:before, input[type='submit'].button--border.button--blue:hover i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--blue:hover i.dashing-clippy:before, input[type='submit'].button--border.button--blue:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--blue:hover .button--navigation:before, input[type='submit'].button--border.button--blue:focus .dashing-icon:before, input[type='submit'].button--border.button--blue:focus i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--blue:focus i.dashing-clippy:before, input[type='submit'].button--border.button--blue:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--blue:focus .button--navigation:before, input[type='reset'].button--border.button--blue:hover .dashing-icon:before, input[type='reset'].button--border.button--blue:hover i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--blue:hover i.dashing-clippy:before, input[type='reset'].button--border.button--blue:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--blue:hover .button--navigation:before, input[type='reset'].button--border.button--blue:focus .dashing-icon:before, input[type='reset'].button--border.button--blue:focus i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--blue:focus i.dashing-clippy:before, input[type='reset'].button--border.button--blue:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--blue:focus .button--navigation:before {
+          color: #FFFFFF;
+          transition: all 50ms ease-in-out; }
+      .button.button--border.button--blue:active, .file-custom .button--border.button--blue.file-custom--button:active, button.button--border.button--blue:active, input[type='submit'].button--border.button--blue:active, input[type='reset'].button--border.button--blue:active {
+        background-color: #294f92; }
+    .button.button--border.button--green, .file-custom .button--border.button--green.file-custom--button, button.button--border.button--green, input[type='submit'].button--border.button--green, input[type='reset'].button--border.button--green {
+      background-color: rgba(255, 255, 255, 0);
+      border-color: #09AA66;
+      color: #09AA66; }
+      .button.button--border.button--green .dashing-icon:before, .file-custom .button--border.button--green.file-custom--button .dashing-icon:before, .button.button--border.button--green i.dashing-tooltip:before, .file-custom .button--border.button--green.file-custom--button i.dashing-tooltip:before,
+      .button.button--border.button--green i.dashing-clippy:before,
+      .file-custom .button--border.button--green.file-custom--button i.dashing-clippy:before, .button.button--border.button--green .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--green .button--navigation:before, .file-custom .button--border.button--green.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--green.file-custom--button .button--navigation:before, button.button--border.button--green .dashing-icon:before, button.button--border.button--green i.dashing-tooltip:before,
+      button.button--border.button--green i.dashing-clippy:before, button.button--border.button--green .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--green .button--navigation:before, input[type='submit'].button--border.button--green .dashing-icon:before, input[type='submit'].button--border.button--green i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--green i.dashing-clippy:before, input[type='submit'].button--border.button--green .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--green .button--navigation:before, input[type='reset'].button--border.button--green .dashing-icon:before, input[type='reset'].button--border.button--green i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--green i.dashing-clippy:before, input[type='reset'].button--border.button--green .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--green .button--navigation:before {
+        color: #09AA66; }
+      .button.button--border.button--green:hover, .file-custom .button--border.button--green.file-custom--button:hover, .button.button--border.button--green:focus, .file-custom .button--border.button--green.file-custom--button:focus, button.button--border.button--green:hover, button.button--border.button--green:focus, input[type='submit'].button--border.button--green:hover, input[type='submit'].button--border.button--green:focus, input[type='reset'].button--border.button--green:hover, input[type='reset'].button--border.button--green:focus {
+        background-color: #067a49;
+        border-color: rgba(255, 255, 255, 0);
+        color: #FFFFFF; }
+        .button.button--border.button--green:hover .dashing-icon:before, .file-custom .button--border.button--green.file-custom--button:hover .dashing-icon:before, .button.button--border.button--green:hover i.dashing-tooltip:before, .file-custom .button--border.button--green.file-custom--button:hover i.dashing-tooltip:before,
+        .button.button--border.button--green:hover i.dashing-clippy:before,
+        .file-custom .button--border.button--green.file-custom--button:hover i.dashing-clippy:before, .button.button--border.button--green:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--green:hover .button--navigation:before, .file-custom .button--border.button--green.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--green.file-custom--button:hover .button--navigation:before, .button.button--border.button--green:focus .dashing-icon:before, .file-custom .button--border.button--green.file-custom--button:focus .dashing-icon:before, .button.button--border.button--green:focus i.dashing-tooltip:before, .file-custom .button--border.button--green.file-custom--button:focus i.dashing-tooltip:before,
+        .button.button--border.button--green:focus i.dashing-clippy:before,
+        .file-custom .button--border.button--green.file-custom--button:focus i.dashing-clippy:before, .button.button--border.button--green:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--green:focus .button--navigation:before, .file-custom .button--border.button--green.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--green.file-custom--button:focus .button--navigation:before, button.button--border.button--green:hover .dashing-icon:before, button.button--border.button--green:hover i.dashing-tooltip:before,
+        button.button--border.button--green:hover i.dashing-clippy:before, button.button--border.button--green:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--green:hover .button--navigation:before, button.button--border.button--green:focus .dashing-icon:before, button.button--border.button--green:focus i.dashing-tooltip:before,
+        button.button--border.button--green:focus i.dashing-clippy:before, button.button--border.button--green:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--green:focus .button--navigation:before, input[type='submit'].button--border.button--green:hover .dashing-icon:before, input[type='submit'].button--border.button--green:hover i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--green:hover i.dashing-clippy:before, input[type='submit'].button--border.button--green:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--green:hover .button--navigation:before, input[type='submit'].button--border.button--green:focus .dashing-icon:before, input[type='submit'].button--border.button--green:focus i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--green:focus i.dashing-clippy:before, input[type='submit'].button--border.button--green:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--green:focus .button--navigation:before, input[type='reset'].button--border.button--green:hover .dashing-icon:before, input[type='reset'].button--border.button--green:hover i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--green:hover i.dashing-clippy:before, input[type='reset'].button--border.button--green:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--green:hover .button--navigation:before, input[type='reset'].button--border.button--green:focus .dashing-icon:before, input[type='reset'].button--border.button--green:focus i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--green:focus i.dashing-clippy:before, input[type='reset'].button--border.button--green:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--green:focus .button--navigation:before {
+          color: #FFFFFF;
+          transition: all 50ms ease-in-out; }
+      .button.button--border.button--green:active, .file-custom .button--border.button--green.file-custom--button:active, button.button--border.button--green:active, input[type='submit'].button--border.button--green:active, input[type='reset'].button--border.button--green:active {
+        background-color: #05613a; }
+    .button.button--border.button--red, .file-custom .button--border.button--red.file-custom--button, button.button--border.button--red, input[type='submit'].button--border.button--red, input[type='reset'].button--border.button--red {
+      background-color: rgba(255, 255, 255, 0);
+      border-color: #DA3D30;
+      color: #DA3D30; }
+      .button.button--border.button--red .dashing-icon:before, .file-custom .button--border.button--red.file-custom--button .dashing-icon:before, .button.button--border.button--red i.dashing-tooltip:before, .file-custom .button--border.button--red.file-custom--button i.dashing-tooltip:before,
+      .button.button--border.button--red i.dashing-clippy:before,
+      .file-custom .button--border.button--red.file-custom--button i.dashing-clippy:before, .button.button--border.button--red .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--red .button--navigation:before, .file-custom .button--border.button--red.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--red.file-custom--button .button--navigation:before, button.button--border.button--red .dashing-icon:before, button.button--border.button--red i.dashing-tooltip:before,
+      button.button--border.button--red i.dashing-clippy:before, button.button--border.button--red .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--red .button--navigation:before, input[type='submit'].button--border.button--red .dashing-icon:before, input[type='submit'].button--border.button--red i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--red i.dashing-clippy:before, input[type='submit'].button--border.button--red .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--red .button--navigation:before, input[type='reset'].button--border.button--red .dashing-icon:before, input[type='reset'].button--border.button--red i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--red i.dashing-clippy:before, input[type='reset'].button--border.button--red .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--red .button--navigation:before {
+        color: #DA3D30; }
+      .button.button--border.button--red:hover, .file-custom .button--border.button--red.file-custom--button:hover, .button.button--border.button--red:focus, .file-custom .button--border.button--red.file-custom--button:focus, button.button--border.button--red:hover, button.button--border.button--red:focus, input[type='submit'].button--border.button--red:hover, input[type='submit'].button--border.button--red:focus, input[type='reset'].button--border.button--red:hover, input[type='reset'].button--border.button--red:focus {
+        background-color: #b62c21;
+        border-color: rgba(255, 255, 255, 0);
+        color: #FFFFFF; }
+        .button.button--border.button--red:hover .dashing-icon:before, .file-custom .button--border.button--red.file-custom--button:hover .dashing-icon:before, .button.button--border.button--red:hover i.dashing-tooltip:before, .file-custom .button--border.button--red.file-custom--button:hover i.dashing-tooltip:before,
+        .button.button--border.button--red:hover i.dashing-clippy:before,
+        .file-custom .button--border.button--red.file-custom--button:hover i.dashing-clippy:before, .button.button--border.button--red:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--red:hover .button--navigation:before, .file-custom .button--border.button--red.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--red.file-custom--button:hover .button--navigation:before, .button.button--border.button--red:focus .dashing-icon:before, .file-custom .button--border.button--red.file-custom--button:focus .dashing-icon:before, .button.button--border.button--red:focus i.dashing-tooltip:before, .file-custom .button--border.button--red.file-custom--button:focus i.dashing-tooltip:before,
+        .button.button--border.button--red:focus i.dashing-clippy:before,
+        .file-custom .button--border.button--red.file-custom--button:focus i.dashing-clippy:before, .button.button--border.button--red:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--red:focus .button--navigation:before, .file-custom .button--border.button--red.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--red.file-custom--button:focus .button--navigation:before, button.button--border.button--red:hover .dashing-icon:before, button.button--border.button--red:hover i.dashing-tooltip:before,
+        button.button--border.button--red:hover i.dashing-clippy:before, button.button--border.button--red:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--red:hover .button--navigation:before, button.button--border.button--red:focus .dashing-icon:before, button.button--border.button--red:focus i.dashing-tooltip:before,
+        button.button--border.button--red:focus i.dashing-clippy:before, button.button--border.button--red:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--red:focus .button--navigation:before, input[type='submit'].button--border.button--red:hover .dashing-icon:before, input[type='submit'].button--border.button--red:hover i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--red:hover i.dashing-clippy:before, input[type='submit'].button--border.button--red:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--red:hover .button--navigation:before, input[type='submit'].button--border.button--red:focus .dashing-icon:before, input[type='submit'].button--border.button--red:focus i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--red:focus i.dashing-clippy:before, input[type='submit'].button--border.button--red:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--red:focus .button--navigation:before, input[type='reset'].button--border.button--red:hover .dashing-icon:before, input[type='reset'].button--border.button--red:hover i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--red:hover i.dashing-clippy:before, input[type='reset'].button--border.button--red:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--red:hover .button--navigation:before, input[type='reset'].button--border.button--red:focus .dashing-icon:before, input[type='reset'].button--border.button--red:focus i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--red:focus i.dashing-clippy:before, input[type='reset'].button--border.button--red:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--red:focus .button--navigation:before {
+          color: #FFFFFF;
+          transition: all 50ms ease-in-out; }
+      .button.button--border.button--red:active, .file-custom .button--border.button--red.file-custom--button:active, button.button--border.button--red:active, input[type='submit'].button--border.button--red:active, input[type='reset'].button--border.button--red:active {
+        background-color: #a1271d; }
+    .button.button--border.button--orange, .file-custom .button--border.button--orange.file-custom--button, button.button--border.button--orange, input[type='submit'].button--border.button--orange, input[type='reset'].button--border.button--orange {
+      background-color: rgba(255, 255, 255, 0);
+      border-color: #FFA11F;
+      color: #FFA11F; }
+      .button.button--border.button--orange .dashing-icon:before, .file-custom .button--border.button--orange.file-custom--button .dashing-icon:before, .button.button--border.button--orange i.dashing-tooltip:before, .file-custom .button--border.button--orange.file-custom--button i.dashing-tooltip:before,
+      .button.button--border.button--orange i.dashing-clippy:before,
+      .file-custom .button--border.button--orange.file-custom--button i.dashing-clippy:before, .button.button--border.button--orange .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--orange .button--navigation:before, .file-custom .button--border.button--orange.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--orange.file-custom--button .button--navigation:before, button.button--border.button--orange .dashing-icon:before, button.button--border.button--orange i.dashing-tooltip:before,
+      button.button--border.button--orange i.dashing-clippy:before, button.button--border.button--orange .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--orange .button--navigation:before, input[type='submit'].button--border.button--orange .dashing-icon:before, input[type='submit'].button--border.button--orange i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--orange i.dashing-clippy:before, input[type='submit'].button--border.button--orange .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--orange .button--navigation:before, input[type='reset'].button--border.button--orange .dashing-icon:before, input[type='reset'].button--border.button--orange i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--orange i.dashing-clippy:before, input[type='reset'].button--border.button--orange .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--orange .button--navigation:before {
+        color: #FFA11F; }
+      .button.button--border.button--orange:hover, .file-custom .button--border.button--orange.file-custom--button:hover, .button.button--border.button--orange:focus, .file-custom .button--border.button--orange.file-custom--button:focus, button.button--border.button--orange:hover, button.button--border.button--orange:focus, input[type='submit'].button--border.button--orange:hover, input[type='submit'].button--border.button--orange:focus, input[type='reset'].button--border.button--orange:hover, input[type='reset'].button--border.button--orange:focus {
+        background-color: #eb8800;
+        border-color: rgba(255, 255, 255, 0);
+        color: #FFFFFF; }
+        .button.button--border.button--orange:hover .dashing-icon:before, .file-custom .button--border.button--orange.file-custom--button:hover .dashing-icon:before, .button.button--border.button--orange:hover i.dashing-tooltip:before, .file-custom .button--border.button--orange.file-custom--button:hover i.dashing-tooltip:before,
+        .button.button--border.button--orange:hover i.dashing-clippy:before,
+        .file-custom .button--border.button--orange.file-custom--button:hover i.dashing-clippy:before, .button.button--border.button--orange:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--orange:hover .button--navigation:before, .file-custom .button--border.button--orange.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--orange.file-custom--button:hover .button--navigation:before, .button.button--border.button--orange:focus .dashing-icon:before, .file-custom .button--border.button--orange.file-custom--button:focus .dashing-icon:before, .button.button--border.button--orange:focus i.dashing-tooltip:before, .file-custom .button--border.button--orange.file-custom--button:focus i.dashing-tooltip:before,
+        .button.button--border.button--orange:focus i.dashing-clippy:before,
+        .file-custom .button--border.button--orange.file-custom--button:focus i.dashing-clippy:before, .button.button--border.button--orange:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--orange:focus .button--navigation:before, .file-custom .button--border.button--orange.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--orange.file-custom--button:focus .button--navigation:before, button.button--border.button--orange:hover .dashing-icon:before, button.button--border.button--orange:hover i.dashing-tooltip:before,
+        button.button--border.button--orange:hover i.dashing-clippy:before, button.button--border.button--orange:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--orange:hover .button--navigation:before, button.button--border.button--orange:focus .dashing-icon:before, button.button--border.button--orange:focus i.dashing-tooltip:before,
+        button.button--border.button--orange:focus i.dashing-clippy:before, button.button--border.button--orange:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--orange:focus .button--navigation:before, input[type='submit'].button--border.button--orange:hover .dashing-icon:before, input[type='submit'].button--border.button--orange:hover i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--orange:hover i.dashing-clippy:before, input[type='submit'].button--border.button--orange:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--orange:hover .button--navigation:before, input[type='submit'].button--border.button--orange:focus .dashing-icon:before, input[type='submit'].button--border.button--orange:focus i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--orange:focus i.dashing-clippy:before, input[type='submit'].button--border.button--orange:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--orange:focus .button--navigation:before, input[type='reset'].button--border.button--orange:hover .dashing-icon:before, input[type='reset'].button--border.button--orange:hover i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--orange:hover i.dashing-clippy:before, input[type='reset'].button--border.button--orange:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--orange:hover .button--navigation:before, input[type='reset'].button--border.button--orange:focus .dashing-icon:before, input[type='reset'].button--border.button--orange:focus i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--orange:focus i.dashing-clippy:before, input[type='reset'].button--border.button--orange:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--orange:focus .button--navigation:before {
+          color: #FFFFFF;
+          transition: all 50ms ease-in-out; }
+      .button.button--border.button--orange:active, .file-custom .button--border.button--orange.file-custom--button:active, button.button--border.button--orange:active, input[type='submit'].button--border.button--orange:active, input[type='reset'].button--border.button--orange:active {
+        background-color: #d27a00; }
+    .button.button--border.button--purple, .file-custom .button--border.button--purple.file-custom--button, button.button--border.button--purple, input[type='submit'].button--border.button--purple, input[type='reset'].button--border.button--purple {
+      background-color: rgba(255, 255, 255, 0);
+      border-color: #9F65AE;
+      color: #9F65AE; }
+      .button.button--border.button--purple .dashing-icon:before, .file-custom .button--border.button--purple.file-custom--button .dashing-icon:before, .button.button--border.button--purple i.dashing-tooltip:before, .file-custom .button--border.button--purple.file-custom--button i.dashing-tooltip:before,
+      .button.button--border.button--purple i.dashing-clippy:before,
+      .file-custom .button--border.button--purple.file-custom--button i.dashing-clippy:before, .button.button--border.button--purple .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--purple .button--navigation:before, .file-custom .button--border.button--purple.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--purple.file-custom--button .button--navigation:before, button.button--border.button--purple .dashing-icon:before, button.button--border.button--purple i.dashing-tooltip:before,
+      button.button--border.button--purple i.dashing-clippy:before, button.button--border.button--purple .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--purple .button--navigation:before, input[type='submit'].button--border.button--purple .dashing-icon:before, input[type='submit'].button--border.button--purple i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--purple i.dashing-clippy:before, input[type='submit'].button--border.button--purple .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--purple .button--navigation:before, input[type='reset'].button--border.button--purple .dashing-icon:before, input[type='reset'].button--border.button--purple i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--purple i.dashing-clippy:before, input[type='reset'].button--border.button--purple .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--purple .button--navigation:before {
+        color: #9F65AE; }
+      .button.button--border.button--purple:hover, .file-custom .button--border.button--purple.file-custom--button:hover, .button.button--border.button--purple:focus, .file-custom .button--border.button--purple.file-custom--button:focus, button.button--border.button--purple:hover, button.button--border.button--purple:focus, input[type='submit'].button--border.button--purple:hover, input[type='submit'].button--border.button--purple:focus, input[type='reset'].button--border.button--purple:hover, input[type='reset'].button--border.button--purple:focus {
+        background-color: #844d93;
+        border-color: rgba(255, 255, 255, 0);
+        color: #FFFFFF; }
+        .button.button--border.button--purple:hover .dashing-icon:before, .file-custom .button--border.button--purple.file-custom--button:hover .dashing-icon:before, .button.button--border.button--purple:hover i.dashing-tooltip:before, .file-custom .button--border.button--purple.file-custom--button:hover i.dashing-tooltip:before,
+        .button.button--border.button--purple:hover i.dashing-clippy:before,
+        .file-custom .button--border.button--purple.file-custom--button:hover i.dashing-clippy:before, .button.button--border.button--purple:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--purple:hover .button--navigation:before, .file-custom .button--border.button--purple.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--purple.file-custom--button:hover .button--navigation:before, .button.button--border.button--purple:focus .dashing-icon:before, .file-custom .button--border.button--purple.file-custom--button:focus .dashing-icon:before, .button.button--border.button--purple:focus i.dashing-tooltip:before, .file-custom .button--border.button--purple.file-custom--button:focus i.dashing-tooltip:before,
+        .button.button--border.button--purple:focus i.dashing-clippy:before,
+        .file-custom .button--border.button--purple.file-custom--button:focus i.dashing-clippy:before, .button.button--border.button--purple:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--purple:focus .button--navigation:before, .file-custom .button--border.button--purple.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--purple.file-custom--button:focus .button--navigation:before, button.button--border.button--purple:hover .dashing-icon:before, button.button--border.button--purple:hover i.dashing-tooltip:before,
+        button.button--border.button--purple:hover i.dashing-clippy:before, button.button--border.button--purple:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--purple:hover .button--navigation:before, button.button--border.button--purple:focus .dashing-icon:before, button.button--border.button--purple:focus i.dashing-tooltip:before,
+        button.button--border.button--purple:focus i.dashing-clippy:before, button.button--border.button--purple:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--purple:focus .button--navigation:before, input[type='submit'].button--border.button--purple:hover .dashing-icon:before, input[type='submit'].button--border.button--purple:hover i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--purple:hover i.dashing-clippy:before, input[type='submit'].button--border.button--purple:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--purple:hover .button--navigation:before, input[type='submit'].button--border.button--purple:focus .dashing-icon:before, input[type='submit'].button--border.button--purple:focus i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--purple:focus i.dashing-clippy:before, input[type='submit'].button--border.button--purple:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--purple:focus .button--navigation:before, input[type='reset'].button--border.button--purple:hover .dashing-icon:before, input[type='reset'].button--border.button--purple:hover i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--purple:hover i.dashing-clippy:before, input[type='reset'].button--border.button--purple:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--purple:hover .button--navigation:before, input[type='reset'].button--border.button--purple:focus .dashing-icon:before, input[type='reset'].button--border.button--purple:focus i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--purple:focus i.dashing-clippy:before, input[type='reset'].button--border.button--purple:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--purple:focus .button--navigation:before {
+          color: #FFFFFF;
+          transition: all 50ms ease-in-out; }
+      .button.button--border.button--purple:active, .file-custom .button--border.button--purple.file-custom--button:active, button.button--border.button--purple:active, input[type='submit'].button--border.button--purple:active, input[type='reset'].button--border.button--purple:active {
+        background-color: #754482; }
+    .button.button--border.button--gray, .file-custom .button--border.button--gray.file-custom--button, .button.button--border.button--secondary, .file-custom .button--border.button--secondary.file-custom--button, button.button--border.button--gray, button.button--border.button--secondary, input[type='submit'].button--border.button--gray, input[type='submit'].button--border.button--secondary, input[type='reset'].button--border.button--gray, input[type='reset'].button--border.button--secondary {
+      background-color: rgba(255, 255, 255, 0);
+      color: #555555;
+      border-color: #878787; }
+      .button.button--border.button--gray:hover, .file-custom .button--border.button--gray.file-custom--button:hover, .button.button--border.button--gray:focus, .file-custom .button--border.button--gray.file-custom--button:focus, .button.button--border.button--secondary:hover, .file-custom .button--border.button--secondary.file-custom--button:hover, .button.button--border.button--secondary:focus, .file-custom .button--border.button--secondary.file-custom--button:focus, button.button--border.button--gray:hover, button.button--border.button--gray:focus, button.button--border.button--secondary:hover, button.button--border.button--secondary:focus, input[type='submit'].button--border.button--gray:hover, input[type='submit'].button--border.button--gray:focus, input[type='submit'].button--border.button--secondary:hover, input[type='submit'].button--border.button--secondary:focus, input[type='reset'].button--border.button--gray:hover, input[type='reset'].button--border.button--gray:focus, input[type='reset'].button--border.button--secondary:hover, input[type='reset'].button--border.button--secondary:focus {
+        background-color: rgba(230, 230, 230, 0);
+        color: #555555; }
+      .button.button--border.button--gray:active, .file-custom .button--border.button--gray.file-custom--button:active, .button.button--border.button--secondary:active, .file-custom .button--border.button--secondary.file-custom--button:active, button.button--border.button--gray:active, button.button--border.button--secondary:active, input[type='submit'].button--border.button--gray:active, input[type='submit'].button--border.button--secondary:active, input[type='reset'].button--border.button--gray:active, input[type='reset'].button--border.button--secondary:active {
+        background-color: rgba(217, 217, 217, 0); }
+      .button.button--border.button--gray:not(.button--transparent) .dashing-icon:before, .file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--border.button--gray:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+      .button.button--border.button--gray:not(.button--transparent) i.dashing-clippy:before,
+      .file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--border.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--gray:not(.button--transparent) .button--navigation:before, .file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--gray.file-custom--button:not(.button--transparent) .button--navigation:before, .button.button--border.button--secondary:not(.button--transparent) .dashing-icon:before, .file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) .dashing-icon:before, .button.button--border.button--secondary:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+      .button.button--border.button--secondary:not(.button--transparent) i.dashing-clippy:before,
+      .file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button.button--border.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--secondary:not(.button--transparent) .button--navigation:before, .file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--secondary.file-custom--button:not(.button--transparent) .button--navigation:before, button.button--border.button--gray:not(.button--transparent) .dashing-icon:before, button.button--border.button--gray:not(.button--transparent) i.dashing-tooltip:before,
+      button.button--border.button--gray:not(.button--transparent) i.dashing-clippy:before, button.button--border.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--gray:not(.button--transparent) .button--navigation:before, button.button--border.button--secondary:not(.button--transparent) .dashing-icon:before, button.button--border.button--secondary:not(.button--transparent) i.dashing-tooltip:before,
+      button.button--border.button--secondary:not(.button--transparent) i.dashing-clippy:before, button.button--border.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--secondary:not(.button--transparent) .button--navigation:before, input[type='submit'].button--border.button--gray:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--border.button--gray:not(.button--transparent) i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--gray:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--border.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--gray:not(.button--transparent) .button--navigation:before, input[type='submit'].button--border.button--secondary:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--border.button--secondary:not(.button--transparent) i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--secondary:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--border.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--secondary:not(.button--transparent) .button--navigation:before, input[type='reset'].button--border.button--gray:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--border.button--gray:not(.button--transparent) i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--gray:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--border.button--gray:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--gray:not(.button--transparent) .button--navigation:before, input[type='reset'].button--border.button--secondary:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--border.button--secondary:not(.button--transparent) i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--secondary:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--border.button--secondary:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--secondary:not(.button--transparent) .button--navigation:before {
+        color: #FFFFFF; }
+      .button.button--border.button--gray:hover, .file-custom .button--border.button--gray.file-custom--button:hover, .button.button--border.button--gray:focus, .file-custom .button--border.button--gray.file-custom--button:focus, .button.button--border.button--secondary:hover, .file-custom .button--border.button--secondary.file-custom--button:hover, .button.button--border.button--secondary:focus, .file-custom .button--border.button--secondary.file-custom--button:focus, button.button--border.button--gray:hover, button.button--border.button--gray:focus, button.button--border.button--secondary:hover, button.button--border.button--secondary:focus, input[type='submit'].button--border.button--gray:hover, input[type='submit'].button--border.button--gray:focus, input[type='submit'].button--border.button--secondary:hover, input[type='submit'].button--border.button--secondary:focus, input[type='reset'].button--border.button--gray:hover, input[type='reset'].button--border.button--gray:focus, input[type='reset'].button--border.button--secondary:hover, input[type='reset'].button--border.button--secondary:focus {
+        background-color: #D4D4D4;
+        color: #222222;
+        border-color: rgba(255, 255, 255, 0); }
+        .button.button--border.button--gray:hover:hover, .file-custom .button--border.button--gray.file-custom--button:hover:hover, .button.button--border.button--gray:hover:focus, .file-custom .button--border.button--gray.file-custom--button:hover:focus, .button.button--border.button--gray:focus:hover, .file-custom .button--border.button--gray.file-custom--button:focus:hover, .button.button--border.button--gray:focus:focus, .file-custom .button--border.button--gray.file-custom--button:focus:focus, .button.button--border.button--secondary:hover:hover, .file-custom .button--border.button--secondary.file-custom--button:hover:hover, .button.button--border.button--secondary:hover:focus, .file-custom .button--border.button--secondary.file-custom--button:hover:focus, .button.button--border.button--secondary:focus:hover, .file-custom .button--border.button--secondary.file-custom--button:focus:hover, .button.button--border.button--secondary:focus:focus, .file-custom .button--border.button--secondary.file-custom--button:focus:focus, button.button--border.button--gray:hover:hover, button.button--border.button--gray:hover:focus, button.button--border.button--gray:focus:hover, button.button--border.button--gray:focus:focus, button.button--border.button--secondary:hover:hover, button.button--border.button--secondary:hover:focus, button.button--border.button--secondary:focus:hover, button.button--border.button--secondary:focus:focus, input[type='submit'].button--border.button--gray:hover:hover, input[type='submit'].button--border.button--gray:hover:focus, input[type='submit'].button--border.button--gray:focus:hover, input[type='submit'].button--border.button--gray:focus:focus, input[type='submit'].button--border.button--secondary:hover:hover, input[type='submit'].button--border.button--secondary:hover:focus, input[type='submit'].button--border.button--secondary:focus:hover, input[type='submit'].button--border.button--secondary:focus:focus, input[type='reset'].button--border.button--gray:hover:hover, input[type='reset'].button--border.button--gray:hover:focus, input[type='reset'].button--border.button--gray:focus:hover, input[type='reset'].button--border.button--gray:focus:focus, input[type='reset'].button--border.button--secondary:hover:hover, input[type='reset'].button--border.button--secondary:hover:focus, input[type='reset'].button--border.button--secondary:focus:hover, input[type='reset'].button--border.button--secondary:focus:focus {
+          background-color: #bbbbbb;
+          color: #222222; }
+        .button.button--border.button--gray:hover:active, .file-custom .button--border.button--gray.file-custom--button:hover:active, .button.button--border.button--gray:focus:active, .file-custom .button--border.button--gray.file-custom--button:focus:active, .button.button--border.button--secondary:hover:active, .file-custom .button--border.button--secondary.file-custom--button:hover:active, .button.button--border.button--secondary:focus:active, .file-custom .button--border.button--secondary.file-custom--button:focus:active, button.button--border.button--gray:hover:active, button.button--border.button--gray:focus:active, button.button--border.button--secondary:hover:active, button.button--border.button--secondary:focus:active, input[type='submit'].button--border.button--gray:hover:active, input[type='submit'].button--border.button--gray:focus:active, input[type='submit'].button--border.button--secondary:hover:active, input[type='submit'].button--border.button--secondary:focus:active, input[type='reset'].button--border.button--gray:hover:active, input[type='reset'].button--border.button--gray:focus:active, input[type='reset'].button--border.button--secondary:hover:active, input[type='reset'].button--border.button--secondary:focus:active {
+          background-color: #aeaeae; }
+        .button.button--border.button--gray:hover:not(.button--transparent) .dashing-icon:before, .file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) .dashing-icon:before, .button.button--border.button--gray:hover:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) i.dashing-tooltip:before,
+        .button.button--border.button--gray:hover:not(.button--transparent) i.dashing-clippy:before,
+        .file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) i.dashing-clippy:before, .button.button--border.button--gray:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--gray:hover:not(.button--transparent) .button--navigation:before, .file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--gray.file-custom--button:hover:not(.button--transparent) .button--navigation:before, .button.button--border.button--gray:focus:not(.button--transparent) .dashing-icon:before, .file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) .dashing-icon:before, .button.button--border.button--gray:focus:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) i.dashing-tooltip:before,
+        .button.button--border.button--gray:focus:not(.button--transparent) i.dashing-clippy:before,
+        .file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) i.dashing-clippy:before, .button.button--border.button--gray:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--gray:focus:not(.button--transparent) .button--navigation:before, .file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--gray.file-custom--button:focus:not(.button--transparent) .button--navigation:before, .button.button--border.button--secondary:hover:not(.button--transparent) .dashing-icon:before, .file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) .dashing-icon:before, .button.button--border.button--secondary:hover:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) i.dashing-tooltip:before,
+        .button.button--border.button--secondary:hover:not(.button--transparent) i.dashing-clippy:before,
+        .file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) i.dashing-clippy:before, .button.button--border.button--secondary:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--secondary:hover:not(.button--transparent) .button--navigation:before, .file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--secondary.file-custom--button:hover:not(.button--transparent) .button--navigation:before, .button.button--border.button--secondary:focus:not(.button--transparent) .dashing-icon:before, .file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) .dashing-icon:before, .button.button--border.button--secondary:focus:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) i.dashing-tooltip:before,
+        .button.button--border.button--secondary:focus:not(.button--transparent) i.dashing-clippy:before,
+        .file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) i.dashing-clippy:before, .button.button--border.button--secondary:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--secondary:focus:not(.button--transparent) .button--navigation:before, .file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--secondary.file-custom--button:focus:not(.button--transparent) .button--navigation:before, button.button--border.button--gray:hover:not(.button--transparent) .dashing-icon:before, button.button--border.button--gray:hover:not(.button--transparent) i.dashing-tooltip:before,
+        button.button--border.button--gray:hover:not(.button--transparent) i.dashing-clippy:before, button.button--border.button--gray:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--gray:hover:not(.button--transparent) .button--navigation:before, button.button--border.button--gray:focus:not(.button--transparent) .dashing-icon:before, button.button--border.button--gray:focus:not(.button--transparent) i.dashing-tooltip:before,
+        button.button--border.button--gray:focus:not(.button--transparent) i.dashing-clippy:before, button.button--border.button--gray:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--gray:focus:not(.button--transparent) .button--navigation:before, button.button--border.button--secondary:hover:not(.button--transparent) .dashing-icon:before, button.button--border.button--secondary:hover:not(.button--transparent) i.dashing-tooltip:before,
+        button.button--border.button--secondary:hover:not(.button--transparent) i.dashing-clippy:before, button.button--border.button--secondary:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--secondary:hover:not(.button--transparent) .button--navigation:before, button.button--border.button--secondary:focus:not(.button--transparent) .dashing-icon:before, button.button--border.button--secondary:focus:not(.button--transparent) i.dashing-tooltip:before,
+        button.button--border.button--secondary:focus:not(.button--transparent) i.dashing-clippy:before, button.button--border.button--secondary:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--secondary:focus:not(.button--transparent) .button--navigation:before, input[type='submit'].button--border.button--gray:hover:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--border.button--gray:hover:not(.button--transparent) i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--gray:hover:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--border.button--gray:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--gray:hover:not(.button--transparent) .button--navigation:before, input[type='submit'].button--border.button--gray:focus:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--border.button--gray:focus:not(.button--transparent) i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--gray:focus:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--border.button--gray:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--gray:focus:not(.button--transparent) .button--navigation:before, input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--secondary:hover:not(.button--transparent) .button--navigation:before, input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) .dashing-icon:before, input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) i.dashing-clippy:before, input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--secondary:focus:not(.button--transparent) .button--navigation:before, input[type='reset'].button--border.button--gray:hover:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--border.button--gray:hover:not(.button--transparent) i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--gray:hover:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--border.button--gray:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--gray:hover:not(.button--transparent) .button--navigation:before, input[type='reset'].button--border.button--gray:focus:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--border.button--gray:focus:not(.button--transparent) i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--gray:focus:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--border.button--gray:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--gray:focus:not(.button--transparent) .button--navigation:before, input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--secondary:hover:not(.button--transparent) .button--navigation:before, input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) .dashing-icon:before, input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--secondary:focus:not(.button--transparent) .button--navigation:before {
+          color: #FFFFFF; }
+      .button.button--border.button--gray .dashing-icon:before, .file-custom .button--border.button--gray.file-custom--button .dashing-icon:before, .button.button--border.button--gray i.dashing-tooltip:before, .file-custom .button--border.button--gray.file-custom--button i.dashing-tooltip:before,
+      .button.button--border.button--gray i.dashing-clippy:before,
+      .file-custom .button--border.button--gray.file-custom--button i.dashing-clippy:before, .button.button--border.button--gray .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--gray .button--navigation:before, .file-custom .button--border.button--gray.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--gray.file-custom--button .button--navigation:before, .button.button--border.button--secondary .dashing-icon:before, .file-custom .button--border.button--secondary.file-custom--button .dashing-icon:before, .button.button--border.button--secondary i.dashing-tooltip:before, .file-custom .button--border.button--secondary.file-custom--button i.dashing-tooltip:before,
+      .button.button--border.button--secondary i.dashing-clippy:before,
+      .file-custom .button--border.button--secondary.file-custom--button i.dashing-clippy:before, .button.button--border.button--secondary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--secondary .button--navigation:before, .file-custom .button--border.button--secondary.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--secondary.file-custom--button .button--navigation:before, button.button--border.button--gray .dashing-icon:before, button.button--border.button--gray i.dashing-tooltip:before,
+      button.button--border.button--gray i.dashing-clippy:before, button.button--border.button--gray .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--gray .button--navigation:before, button.button--border.button--secondary .dashing-icon:before, button.button--border.button--secondary i.dashing-tooltip:before,
+      button.button--border.button--secondary i.dashing-clippy:before, button.button--border.button--secondary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--secondary .button--navigation:before, input[type='submit'].button--border.button--gray .dashing-icon:before, input[type='submit'].button--border.button--gray i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--gray i.dashing-clippy:before, input[type='submit'].button--border.button--gray .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--gray .button--navigation:before, input[type='submit'].button--border.button--secondary .dashing-icon:before, input[type='submit'].button--border.button--secondary i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--secondary i.dashing-clippy:before, input[type='submit'].button--border.button--secondary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--secondary .button--navigation:before, input[type='reset'].button--border.button--gray .dashing-icon:before, input[type='reset'].button--border.button--gray i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--gray i.dashing-clippy:before, input[type='reset'].button--border.button--gray .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--gray .button--navigation:before, input[type='reset'].button--border.button--secondary .dashing-icon:before, input[type='reset'].button--border.button--secondary i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--secondary i.dashing-clippy:before, input[type='reset'].button--border.button--secondary .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--secondary .button--navigation:before {
+        color: #3B3B3B !important;
+        transition: all 50ms ease-in-out; }
+    .button.button--border.button--white, .file-custom .button--border.button--white.file-custom--button, button.button--border.button--white, input[type='submit'].button--border.button--white, input[type='reset'].button--border.button--white {
+      background-color: rgba(255, 255, 255, 0);
+      border-color: #FFFFFF;
+      color: #FFFFFF; }
+      .button.button--border.button--white .dashing-icon:before, .file-custom .button--border.button--white.file-custom--button .dashing-icon:before, .button.button--border.button--white i.dashing-tooltip:before, .file-custom .button--border.button--white.file-custom--button i.dashing-tooltip:before,
+      .button.button--border.button--white i.dashing-clippy:before,
+      .file-custom .button--border.button--white.file-custom--button i.dashing-clippy:before, .button.button--border.button--white .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--white .button--navigation:before, .file-custom .button--border.button--white.file-custom--button .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button .button--navigation:before, button.button--border.button--white .dashing-icon:before, button.button--border.button--white i.dashing-tooltip:before,
+      button.button--border.button--white i.dashing-clippy:before, button.button--border.button--white .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--white .button--navigation:before, input[type='submit'].button--border.button--white .dashing-icon:before, input[type='submit'].button--border.button--white i.dashing-tooltip:before,
+      input[type='submit'].button--border.button--white i.dashing-clippy:before, input[type='submit'].button--border.button--white .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--white .button--navigation:before, input[type='reset'].button--border.button--white .dashing-icon:before, input[type='reset'].button--border.button--white i.dashing-tooltip:before,
+      input[type='reset'].button--border.button--white i.dashing-clippy:before, input[type='reset'].button--border.button--white .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--white .button--navigation:before {
+        color: #FFFFFF; }
+      .button.button--border.button--white:hover, .file-custom .button--border.button--white.file-custom--button:hover, .button.button--border.button--white:focus, .file-custom .button--border.button--white.file-custom--button:focus, button.button--border.button--white:hover, button.button--border.button--white:focus, input[type='submit'].button--border.button--white:hover, input[type='submit'].button--border.button--white:focus, input[type='reset'].button--border.button--white:hover, input[type='reset'].button--border.button--white:focus {
+        background-color: #e6e6e6;
+        border-color: rgba(255, 255, 255, 0);
+        color: #FFFFFF; }
+        .button.button--border.button--white:hover .dashing-icon:before, .file-custom .button--border.button--white.file-custom--button:hover .dashing-icon:before, .button.button--border.button--white:hover i.dashing-tooltip:before, .file-custom .button--border.button--white.file-custom--button:hover i.dashing-tooltip:before,
+        .button.button--border.button--white:hover i.dashing-clippy:before,
+        .file-custom .button--border.button--white.file-custom--button:hover i.dashing-clippy:before, .button.button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--white:hover .button--navigation:before, .file-custom .button--border.button--white.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button:hover .button--navigation:before, .button.button--border.button--white:focus .dashing-icon:before, .file-custom .button--border.button--white.file-custom--button:focus .dashing-icon:before, .button.button--border.button--white:focus i.dashing-tooltip:before, .file-custom .button--border.button--white.file-custom--button:focus i.dashing-tooltip:before,
+        .button.button--border.button--white:focus i.dashing-clippy:before,
+        .file-custom .button--border.button--white.file-custom--button:focus i.dashing-clippy:before, .button.button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--white:focus .button--navigation:before, .file-custom .button--border.button--white.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button:focus .button--navigation:before, button.button--border.button--white:hover .dashing-icon:before, button.button--border.button--white:hover i.dashing-tooltip:before,
+        button.button--border.button--white:hover i.dashing-clippy:before, button.button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--white:hover .button--navigation:before, button.button--border.button--white:focus .dashing-icon:before, button.button--border.button--white:focus i.dashing-tooltip:before,
+        button.button--border.button--white:focus i.dashing-clippy:before, button.button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--white:focus .button--navigation:before, input[type='submit'].button--border.button--white:hover .dashing-icon:before, input[type='submit'].button--border.button--white:hover i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--white:hover i.dashing-clippy:before, input[type='submit'].button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--white:hover .button--navigation:before, input[type='submit'].button--border.button--white:focus .dashing-icon:before, input[type='submit'].button--border.button--white:focus i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--white:focus i.dashing-clippy:before, input[type='submit'].button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--white:focus .button--navigation:before, input[type='reset'].button--border.button--white:hover .dashing-icon:before, input[type='reset'].button--border.button--white:hover i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--white:hover i.dashing-clippy:before, input[type='reset'].button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--white:hover .button--navigation:before, input[type='reset'].button--border.button--white:focus .dashing-icon:before, input[type='reset'].button--border.button--white:focus i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--white:focus i.dashing-clippy:before, input[type='reset'].button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--white:focus .button--navigation:before {
+          color: #FFFFFF;
+          transition: all 50ms ease-in-out; }
+      .button.button--border.button--white:active, .file-custom .button--border.button--white.file-custom--button:active, button.button--border.button--white:active, input[type='submit'].button--border.button--white:active, input[type='reset'].button--border.button--white:active {
+        background-color: #d9d9d9; }
+      .button.button--border.button--white:hover, .file-custom .button--border.button--white.file-custom--button:hover, .button.button--border.button--white:focus, .file-custom .button--border.button--white.file-custom--button:focus, button.button--border.button--white:hover, button.button--border.button--white:focus, input[type='submit'].button--border.button--white:hover, input[type='submit'].button--border.button--white:focus, input[type='reset'].button--border.button--white:hover, input[type='reset'].button--border.button--white:focus {
+        color: #3B3B3B !important; }
+        .button.button--border.button--white:hover .dashing-icon:before, .file-custom .button--border.button--white.file-custom--button:hover .dashing-icon:before, .button.button--border.button--white:hover i.dashing-tooltip:before, .file-custom .button--border.button--white.file-custom--button:hover i.dashing-tooltip:before,
+        .button.button--border.button--white:hover i.dashing-clippy:before,
+        .file-custom .button--border.button--white.file-custom--button:hover i.dashing-clippy:before, .button.button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--white:hover .button--navigation:before, .file-custom .button--border.button--white.file-custom--button:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button:hover .button--navigation:before, .button.button--border.button--white:focus .dashing-icon:before, .file-custom .button--border.button--white.file-custom--button:focus .dashing-icon:before, .button.button--border.button--white:focus i.dashing-tooltip:before, .file-custom .button--border.button--white.file-custom--button:focus i.dashing-tooltip:before,
+        .button.button--border.button--white:focus i.dashing-clippy:before,
+        .file-custom .button--border.button--white.file-custom--button:focus i.dashing-clippy:before, .button.button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--border.button--white:focus .button--navigation:before, .file-custom .button--border.button--white.file-custom--button:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--border.button--white.file-custom--button:focus .button--navigation:before, button.button--border.button--white:hover .dashing-icon:before, button.button--border.button--white:hover i.dashing-tooltip:before,
+        button.button--border.button--white:hover i.dashing-clippy:before, button.button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--white:hover .button--navigation:before, button.button--border.button--white:focus .dashing-icon:before, button.button--border.button--white:focus i.dashing-tooltip:before,
+        button.button--border.button--white:focus i.dashing-clippy:before, button.button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title button.button--border.button--white:focus .button--navigation:before, input[type='submit'].button--border.button--white:hover .dashing-icon:before, input[type='submit'].button--border.button--white:hover i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--white:hover i.dashing-clippy:before, input[type='submit'].button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--white:hover .button--navigation:before, input[type='submit'].button--border.button--white:focus .dashing-icon:before, input[type='submit'].button--border.button--white:focus i.dashing-tooltip:before,
+        input[type='submit'].button--border.button--white:focus i.dashing-clippy:before, input[type='submit'].button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='submit'].button--border.button--white:focus .button--navigation:before, input[type='reset'].button--border.button--white:hover .dashing-icon:before, input[type='reset'].button--border.button--white:hover i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--white:hover i.dashing-clippy:before, input[type='reset'].button--border.button--white:hover .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--white:hover .button--navigation:before, input[type='reset'].button--border.button--white:focus .dashing-icon:before, input[type='reset'].button--border.button--white:focus i.dashing-tooltip:before,
+        input[type='reset'].button--border.button--white:focus i.dashing-clippy:before, input[type='reset'].button--border.button--white:focus .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--border.button--white:focus .button--navigation:before {
+          color: #3B3B3B !important;
+          transition: all 50ms ease-in-out; }
+  .button .dashing-icon.flow-opposite, .file-custom .file-custom--button .dashing-icon.flow-opposite, .button i.flow-opposite.dashing-tooltip, .file-custom .file-custom--button i.flow-opposite.dashing-tooltip,
+  .button i.flow-opposite.dashing-clippy,
+  .file-custom .file-custom--button i.flow-opposite.dashing-clippy, .button .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title .button .flow-opposite.button--navigation, .file-custom .file-custom--button .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title .file-custom .file-custom--button .flow-opposite.button--navigation, button .dashing-icon.flow-opposite, button i.flow-opposite.dashing-tooltip,
+  button i.flow-opposite.dashing-clippy, button .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title button .flow-opposite.button--navigation, input[type='submit'] .dashing-icon.flow-opposite, input[type='submit'] i.flow-opposite.dashing-tooltip,
+  input[type='submit'] i.flow-opposite.dashing-clippy, input[type='submit'] .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title input[type='submit'] .flow-opposite.button--navigation, input[type='reset'] .dashing-icon.flow-opposite, input[type='reset'] i.flow-opposite.dashing-tooltip,
+  input[type='reset'] i.flow-opposite.dashing-clippy, input[type='reset'] .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title input[type='reset'] .flow-opposite.button--navigation {
+    display: inline-block; }
+
+.button--icon {
+  border-radius: 50px !important;
+  padding: 1rem; }
+  .button--icon.button--icon--small, .button--icon.button--small, .app-menu .app-context .app-title .button--icon.button--navigation {
+    padding: 0.6rem; }
+  .button--icon.button--transparent:hover, .button--icon.button--transparent:focus {
+    background-color: rgba(110, 110, 110, 0.2);
+    color: rgba(255, 255, 255, 0);
+    opacity: 1; }
+    .button--icon.button--transparent:hover:hover, .button--icon.button--transparent:hover:focus, .button--icon.button--transparent:focus:hover, .button--icon.button--transparent:focus:focus {
+      background-color: rgba(85, 85, 85, 0.2);
+      color: rgba(255, 255, 255, 0); }
+    .button--icon.button--transparent:hover:active, .button--icon.button--transparent:focus:active {
+      background-color: rgba(72, 72, 72, 0.2); }
+    .button--icon.button--transparent:hover:not(.button--transparent) .dashing-icon:before, .button--icon.button--transparent:hover:not(.button--transparent) i.dashing-tooltip:before,
+    .button--icon.button--transparent:hover:not(.button--transparent) i.dashing-clippy:before, .button--icon.button--transparent:hover:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button--icon.button--transparent:hover:not(.button--transparent) .button--navigation:before, .button--icon.button--transparent:focus:not(.button--transparent) .dashing-icon:before, .button--icon.button--transparent:focus:not(.button--transparent) i.dashing-tooltip:before,
+    .button--icon.button--transparent:focus:not(.button--transparent) i.dashing-clippy:before, .button--icon.button--transparent:focus:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button--icon.button--transparent:focus:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+
+.button ~ .action, .file-custom .file-custom--button ~ .action {
+  margin-left: 0.5rem; }
+
+.button-group {
+  margin: 0;
+  padding: 0;
+  overflow: auto; }
+  .button-group.button-group--gray .button, .button-group.button-group--gray .file-custom .file-custom--button, .file-custom .button-group.button-group--gray .file-custom--button, .button-group.button-group--grey .button, .button-group.button-group--grey .file-custom .file-custom--button, .file-custom .button-group.button-group--grey .file-custom--button {
+    background-color: #D4D4D4;
+    color: #222222; }
+    .button-group.button-group--gray .button:hover, .button-group.button-group--gray .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--gray .file-custom--button:hover, .button-group.button-group--gray .button:focus, .button-group.button-group--gray .file-custom .file-custom--button:focus, .file-custom .button-group.button-group--gray .file-custom--button:focus, .button-group.button-group--grey .button:hover, .button-group.button-group--grey .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--grey .file-custom--button:hover, .button-group.button-group--grey .button:focus, .button-group.button-group--grey .file-custom .file-custom--button:focus, .file-custom .button-group.button-group--grey .file-custom--button:focus {
+      background-color: #bbbbbb;
+      color: #222222; }
+    .button-group.button-group--gray .button:active, .button-group.button-group--gray .file-custom .file-custom--button:active, .file-custom .button-group.button-group--gray .file-custom--button:active, .button-group.button-group--grey .button:active, .button-group.button-group--grey .file-custom .file-custom--button:active, .file-custom .button-group.button-group--grey .file-custom--button:active {
+      background-color: #aeaeae; }
+    .button-group.button-group--gray .button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before, .file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--gray .button:not(.button--transparent) i.dashing-tooltip:before, .button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button-group.button-group--gray .button:not(.button--transparent) i.dashing-clippy:before,
+    .button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button-group.button-group--gray .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--gray .button:not(.button--transparent) .button--navigation:before, .button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--gray .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before, .file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button-group.button-group--gray .file-custom--button:not(.button--transparent) .button--navigation:before, .button-group.button-group--grey .button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before, .file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--grey .button:not(.button--transparent) i.dashing-tooltip:before, .button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button-group.button-group--grey .button:not(.button--transparent) i.dashing-clippy:before,
+    .button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button-group.button-group--grey .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--grey .button:not(.button--transparent) .button--navigation:before, .button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--grey .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before, .file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button-group.button-group--grey .file-custom--button:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button-group.button-group--gray .button--radio input:checked ~ label, .button-group.button-group--grey .button--radio input:checked ~ label {
+    background-color: #878787;
+    color: #FFFFFF; }
+  .button-group.button-group--blue .button, .button-group.button-group--blue .file-custom .file-custom--button, .file-custom .button-group.button-group--blue .file-custom--button {
+    background-color: #3F70C9;
+    color: #FFFFFF; }
+    .button-group.button-group--blue .button:hover, .button-group.button-group--blue .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--blue .file-custom--button:hover, .button-group.button-group--blue .button:focus, .button-group.button-group--blue .file-custom .file-custom--button:focus, .file-custom .button-group.button-group--blue .file-custom--button:focus {
+      background-color: #2f59a6;
+      color: #FFFFFF; }
+    .button-group.button-group--blue .button:active, .button-group.button-group--blue .file-custom .file-custom--button:active, .file-custom .button-group.button-group--blue .file-custom--button:active {
+      background-color: #294f92; }
+    .button-group.button-group--blue .button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before, .file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--blue .button:not(.button--transparent) i.dashing-tooltip:before, .button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button-group.button-group--blue .button:not(.button--transparent) i.dashing-clippy:before,
+    .button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button-group.button-group--blue .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--blue .button:not(.button--transparent) .button--navigation:before, .button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--blue .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before, .file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button-group.button-group--blue .file-custom--button:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button-group.button-group--blue .button--radio input:checked ~ label {
+    background-color: #375AA0; }
+  .button-group.button-group--green .button, .button-group.button-group--green .file-custom .file-custom--button, .file-custom .button-group.button-group--green .file-custom--button {
+    background-color: #09AA66;
+    color: #FFFFFF; }
+    .button-group.button-group--green .button:hover, .button-group.button-group--green .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--green .file-custom--button:hover, .button-group.button-group--green .button:focus, .button-group.button-group--green .file-custom .file-custom--button:focus, .file-custom .button-group.button-group--green .file-custom--button:focus {
+      background-color: #067a49;
+      color: #FFFFFF; }
+    .button-group.button-group--green .button:active, .button-group.button-group--green .file-custom .file-custom--button:active, .file-custom .button-group.button-group--green .file-custom--button:active {
+      background-color: #05613a; }
+    .button-group.button-group--green .button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before, .file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--green .button:not(.button--transparent) i.dashing-tooltip:before, .button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button-group.button-group--green .button:not(.button--transparent) i.dashing-clippy:before,
+    .button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button-group.button-group--green .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--green .button:not(.button--transparent) .button--navigation:before, .button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--green .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before, .file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button-group.button-group--green .file-custom--button:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button-group.button-group--green .button--radio input:checked ~ label {
+    background-color: #007E39; }
+  .button-group.button-group--orange .button, .button-group.button-group--orange .file-custom .file-custom--button, .file-custom .button-group.button-group--orange .file-custom--button {
+    background-color: #FFA11F;
+    color: #FFFFFF; }
+    .button-group.button-group--orange .button:hover, .button-group.button-group--orange .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--orange .file-custom--button:hover, .button-group.button-group--orange .button:focus, .button-group.button-group--orange .file-custom .file-custom--button:focus, .file-custom .button-group.button-group--orange .file-custom--button:focus {
+      background-color: #eb8800;
+      color: #FFFFFF; }
+    .button-group.button-group--orange .button:active, .button-group.button-group--orange .file-custom .file-custom--button:active, .file-custom .button-group.button-group--orange .file-custom--button:active {
+      background-color: #d27a00; }
+    .button-group.button-group--orange .button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before, .file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--orange .button:not(.button--transparent) i.dashing-tooltip:before, .button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button-group.button-group--orange .button:not(.button--transparent) i.dashing-clippy:before,
+    .button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button-group.button-group--orange .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--orange .button:not(.button--transparent) .button--navigation:before, .button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--orange .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before, .file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button-group.button-group--orange .file-custom--button:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button-group.button-group--orange .button--radio input:checked ~ label {
+    background-color: #AA6000; }
+  .button-group.button-group--purple .button, .button-group.button-group--purple .file-custom .file-custom--button, .file-custom .button-group.button-group--purple .file-custom--button {
+    background-color: #9F65AE;
+    color: #FFFFFF; }
+    .button-group.button-group--purple .button:hover, .button-group.button-group--purple .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--purple .file-custom--button:hover, .button-group.button-group--purple .button:focus, .button-group.button-group--purple .file-custom .file-custom--button:focus, .file-custom .button-group.button-group--purple .file-custom--button:focus {
+      background-color: #844d93;
+      color: #FFFFFF; }
+    .button-group.button-group--purple .button:active, .button-group.button-group--purple .file-custom .file-custom--button:active, .file-custom .button-group.button-group--purple .file-custom--button:active {
+      background-color: #754482; }
+    .button-group.button-group--purple .button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before, .file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--purple .button:not(.button--transparent) i.dashing-tooltip:before, .button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button-group.button-group--purple .button:not(.button--transparent) i.dashing-clippy:before,
+    .button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button-group.button-group--purple .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--purple .button:not(.button--transparent) .button--navigation:before, .button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--purple .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before, .file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button-group.button-group--purple .file-custom--button:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button-group.button-group--purple .button--radio input:checked ~ label {
+    background-color: #290036; }
+  .button-group.button-group--red .button, .button-group.button-group--red .file-custom .file-custom--button, .file-custom .button-group.button-group--red .file-custom--button {
+    background-color: #DA3D30;
+    color: #FFFFFF; }
+    .button-group.button-group--red .button:hover, .button-group.button-group--red .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--red .file-custom--button:hover, .button-group.button-group--red .button:focus, .button-group.button-group--red .file-custom .file-custom--button:focus, .file-custom .button-group.button-group--red .file-custom--button:focus {
+      background-color: #b62c21;
+      color: #FFFFFF; }
+    .button-group.button-group--red .button:active, .button-group.button-group--red .file-custom .file-custom--button:active, .file-custom .button-group.button-group--red .file-custom--button:active {
+      background-color: #a1271d; }
+    .button-group.button-group--red .button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) .dashing-icon:before, .file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) .dashing-icon:before, .button-group.button-group--red .button:not(.button--transparent) i.dashing-tooltip:before, .button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) i.dashing-tooltip:before, .file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) i.dashing-tooltip:before,
+    .button-group.button-group--red .button:not(.button--transparent) i.dashing-clippy:before,
+    .button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) i.dashing-clippy:before,
+    .file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) i.dashing-clippy:before, .button-group.button-group--red .button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--red .button:not(.button--transparent) .button--navigation:before, .button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button-group.button-group--red .file-custom .file-custom--button:not(.button--transparent) .button--navigation:before, .file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button-group.button-group--red .file-custom--button:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+  .button-group.button-group--red .button--radio input:checked ~ label {
+    background-color: #910000; }
+  .button-group.button-group--border .button--radio:first-of-type .button, .button-group.button-group--border .button--radio:first-of-type .file-custom .file-custom--button, .file-custom .button-group.button-group--border .button--radio:first-of-type .file-custom--button {
+    border-left: 2px solid #BABABA; }
+  .button-group.button-group--border .button--radio:first-of-type input:checked ~ label {
+    border-color: #09AA66; }
+  .button-group.button-group--border .button--radio:last-of-type .button, .button-group.button-group--border .button--radio:last-of-type .file-custom .file-custom--button, .file-custom .button-group.button-group--border .button--radio:last-of-type .file-custom--button {
+    border-right: 2px solid #BABABA; }
+  .button-group.button-group--border .button--radio:last-of-type input:checked ~ label {
+    border-color: #09AA66; }
+  .button-group.button-group--border .button, .button-group.button-group--border .file-custom .file-custom--button, .file-custom .button-group.button-group--border .file-custom--button {
+    border: 2px solid #BABABA;
+    display: inline-block;
+    padding: 0.4rem 0.9rem;
+    padding-top: 0.35rem; }
+  .button-group.button-group--border.button-group--gray .button--radio input:checked ~ label, .button-group.button-group--border.button-group--grey .button--radio input:checked ~ label {
+    background-color: #6E6E6E;
+    border-color: #6E6E6E;
+    color: #FFFFFF; }
+    .button-group.button-group--border.button-group--gray .button--radio input:checked ~ label:hover, .button-group.button-group--border.button-group--grey .button--radio input:checked ~ label:hover {
+      color: #FFFFFF; }
+  .button-group.button-group--border.button-group--gray .button--radio .button, .button-group.button-group--border.button-group--gray .button--radio .file-custom .file-custom--button, .file-custom .button-group.button-group--border.button-group--gray .button--radio .file-custom--button, .button-group.button-group--border.button-group--grey .button--radio .button, .button-group.button-group--border.button-group--grey .button--radio .file-custom .file-custom--button, .file-custom .button-group.button-group--border.button-group--grey .button--radio .file-custom--button {
+    background-color: transparent;
+    color: #6E6E6E; }
+    .button-group.button-group--border.button-group--gray .button--radio .button:hover, .button-group.button-group--border.button-group--gray .button--radio .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--border.button-group--gray .button--radio .file-custom--button:hover, .button-group.button-group--border.button-group--grey .button--radio .button:hover, .button-group.button-group--border.button-group--grey .button--radio .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--border.button-group--grey .button--radio .file-custom--button:hover {
+      color: #6E6E6E; }
+  .button-group.button-group--border.button-group--blue .button--radio input:checked ~ label {
+    background-color: #3F70C9;
+    border-color: #3F70C9;
+    color: #FFFFFF; }
+    .button-group.button-group--border.button-group--blue .button--radio input:checked ~ label:hover {
+      color: #FFFFFF; }
+  .button-group.button-group--border.button-group--blue .button--radio .button, .button-group.button-group--border.button-group--blue .button--radio .file-custom .file-custom--button, .file-custom .button-group.button-group--border.button-group--blue .button--radio .file-custom--button {
+    background-color: transparent;
+    color: #6E6E6E; }
+    .button-group.button-group--border.button-group--blue .button--radio .button:hover, .button-group.button-group--border.button-group--blue .button--radio .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--border.button-group--blue .button--radio .file-custom--button:hover {
+      color: #3F70C9; }
+  .button-group.button-group--border.button-group--green .button--radio input:checked ~ label {
+    background-color: #09AA66;
+    border-color: #09AA66;
+    color: #FFFFFF; }
+    .button-group.button-group--border.button-group--green .button--radio input:checked ~ label:hover {
+      color: #FFFFFF; }
+  .button-group.button-group--border.button-group--green .button--radio .button, .button-group.button-group--border.button-group--green .button--radio .file-custom .file-custom--button, .file-custom .button-group.button-group--border.button-group--green .button--radio .file-custom--button {
+    background-color: transparent;
+    color: #6E6E6E; }
+    .button-group.button-group--border.button-group--green .button--radio .button:hover, .button-group.button-group--border.button-group--green .button--radio .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--border.button-group--green .button--radio .file-custom--button:hover {
+      color: #09AA66; }
+  .button-group.button-group--border.button-group--orange .button--radio input:checked ~ label {
+    background-color: #FFA11F;
+    border-color: #FFA11F;
+    color: #FFFFFF; }
+    .button-group.button-group--border.button-group--orange .button--radio input:checked ~ label:hover {
+      color: #FFFFFF; }
+  .button-group.button-group--border.button-group--orange .button--radio .button, .button-group.button-group--border.button-group--orange .button--radio .file-custom .file-custom--button, .file-custom .button-group.button-group--border.button-group--orange .button--radio .file-custom--button {
+    background-color: transparent;
+    color: #6E6E6E; }
+    .button-group.button-group--border.button-group--orange .button--radio .button:hover, .button-group.button-group--border.button-group--orange .button--radio .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--border.button-group--orange .button--radio .file-custom--button:hover {
+      color: #FFA11F; }
+  .button-group.button-group--border.button-group--purple .button--radio input:checked ~ label {
+    background-color: #9F65AE;
+    border-color: #9F65AE;
+    color: #FFFFFF; }
+    .button-group.button-group--border.button-group--purple .button--radio input:checked ~ label:hover {
+      color: #FFFFFF; }
+  .button-group.button-group--border.button-group--purple .button--radio .button, .button-group.button-group--border.button-group--purple .button--radio .file-custom .file-custom--button, .file-custom .button-group.button-group--border.button-group--purple .button--radio .file-custom--button {
+    background-color: transparent;
+    color: #6E6E6E; }
+    .button-group.button-group--border.button-group--purple .button--radio .button:hover, .button-group.button-group--border.button-group--purple .button--radio .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--border.button-group--purple .button--radio .file-custom--button:hover {
+      color: #9F65AE; }
+  .button-group.button-group--border.button-group--red .button--radio input:checked ~ label {
+    background-color: #DA3D30;
+    border-color: #DA3D30;
+    color: #FFFFFF; }
+    .button-group.button-group--border.button-group--red .button--radio input:checked ~ label:hover {
+      color: #FFFFFF; }
+  .button-group.button-group--border.button-group--red .button--radio .button, .button-group.button-group--border.button-group--red .button--radio .file-custom .file-custom--button, .file-custom .button-group.button-group--border.button-group--red .button--radio .file-custom--button {
+    background-color: transparent;
+    color: #6E6E6E; }
+    .button-group.button-group--border.button-group--red .button--radio .button:hover, .button-group.button-group--border.button-group--red .button--radio .file-custom .file-custom--button:hover, .file-custom .button-group.button-group--border.button-group--red .button--radio .file-custom--button:hover {
+      color: #DA3D30; }
+  .button-group .button--radio {
+    display: inline-block;
+    float: left; }
+    .button-group .button--radio:first-of-type label {
+      margin-left: 0; }
+    .button-group .button--radio input {
+      display: none; }
+    .button-group .button--radio label {
+      border-radius: 0;
+      display: inline-block;
+      margin: 0 0 0 -2px; }
+      @media all and (max-width: 40em) {
+        .button-group .button--radio label {
+          border-left: 1px; } }
+
+/* Vertical Button Styles
+  =========================================================================== */
+.button-group.button-group--vertical {
+  display: -webkit-inline-box;
+  display: -moz-inline-box;
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
+  display: inline-flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -moz-box-orient: vertical;
+  -moz-box-direction: normal;
+  -ms-flex-direction: column;
+  -webkit-flex-direction: column;
+  flex-direction: column; }
+  .button-group.button-group--vertical .button--radio {
+    display: block; }
+    .button-group.button-group--vertical .button--radio:first-of-type label {
+      margin-top: 2px; }
+    .button-group.button-group--vertical .button--radio:last-of-type label {
+      margin-bottom: 2px; }
+    .button-group.button-group--vertical .button--radio label {
+      display: block !important;
+      border-width: 2px;
+      margin: -1px auto; }
+
+@media all and (max-width: 40em) {
+  .button-group.button-group--vertical_phone {
+    display: -webkit-inline-box;
+    display: -moz-inline-box;
+    display: -ms-inline-flexbox;
+    display: -webkit-inline-flex;
+    display: inline-flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -moz-box-orient: vertical;
+    -moz-box-direction: normal;
+    -ms-flex-direction: column;
+    -webkit-flex-direction: column;
+    flex-direction: column; }
+    .button-group.button-group--vertical_phone .button--radio {
+      display: block; }
+      .button-group.button-group--vertical_phone .button--radio:first-of-type label {
+        margin-top: 2px; }
+      .button-group.button-group--vertical_phone .button--radio:last-of-type label {
+        margin-bottom: 2px; }
+      .button-group.button-group--vertical_phone .button--radio label {
+        display: block !important;
+        border-width: 2px;
+        margin: -1px auto; } }
+
+@media all and (min-width: 40em) {
+  .button-group.button-group--vertical_tablet {
+    display: -webkit-inline-box;
+    display: -moz-inline-box;
+    display: -ms-inline-flexbox;
+    display: -webkit-inline-flex;
+    display: inline-flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -moz-box-orient: vertical;
+    -moz-box-direction: normal;
+    -ms-flex-direction: column;
+    -webkit-flex-direction: column;
+    flex-direction: column; }
+    .button-group.button-group--vertical_tablet .button--radio {
+      display: block; }
+      .button-group.button-group--vertical_tablet .button--radio:first-of-type label {
+        margin-top: 2px; }
+      .button-group.button-group--vertical_tablet .button--radio:last-of-type label {
+        margin-bottom: 2px; }
+      .button-group.button-group--vertical_tablet .button--radio label {
+        display: block !important;
+        border-width: 2px;
+        margin: -1px auto; } }
+
+/* Border Radius Options
+  =========================================================================== */
+.button-group .button--radio:first-of-type label {
+  border-radius: 50px 0 0 50px; }
+.button-group .button--radio:last-of-type label {
+  border-radius: 0 50px 50px 0; }
+.button-group.button--smooth .button--radio:first-of-type label, .app-menu .app-context .app-title .button-group.button--navigation .button--radio:first-of-type label {
+  border-radius: 5px 0 0 5px; }
+.button-group.button--smooth .button--radio:last-of-type label, .app-menu .app-context .app-title .button-group.button--navigation .button--radio:last-of-type label {
+  border-radius: 0 5px 5px 0; }
+.button-group.button--square .button--radio:first-of-type label,
+.button-group.button--square .button--radio:last-of-type label {
+  border-radius: 0; }
+.button-group.button-group--vertical .button--radio:first-of-type label {
+  border-radius: 10px 10px 0 0; }
+.button-group.button-group--vertical .button--radio:last-of-type label {
+  border-radius: 0 0 10px 10px; }
+.button-group.button-group--vertical.button--smooth .button--radio:first-of-type label, .app-menu .app-context .app-title .button-group.button-group--vertical.button--navigation .button--radio:first-of-type label {
+  border-radius: 5px 5px 0 0; }
+.button-group.button-group--vertical.button--smooth .button--radio:last-of-type label, .app-menu .app-context .app-title .button-group.button-group--vertical.button--navigation .button--radio:last-of-type label {
+  border-radius: 0 0 5px 5px; }
+.button-group.button-group--vertical.button--square .button--radio:first-of-type label, .button-group.button-group--vertical.button--square .button--radio:last-of-type label {
+  border-radius: 0; }
+@media all and (max-width: 40em) {
+  .button-group.button-group--vertical_phone .button--radio:first-of-type label {
+    border-radius: 10px 10px 0 0; }
+  .button-group.button-group--vertical_phone .button--radio:last-of-type label {
+    border-radius: 0 0 10px 10px; }
+  .button-group.button-group--vertical_phone.button--smooth .button--radio:first-of-type label, .app-menu .app-context .app-title .button-group.button-group--vertical_phone.button--navigation .button--radio:first-of-type label {
+    border-radius: 5px 5px 0 0; }
+  .button-group.button-group--vertical_phone.button--smooth .button--radio:last-of-type label, .app-menu .app-context .app-title .button-group.button-group--vertical_phone.button--navigation .button--radio:last-of-type label {
+    border-radius: 0 0 5px 5px; }
+  .button-group.button-group--vertical_phone.button--square .button--radio:first-of-type label, .button-group.button-group--vertical_phone.button--square .button--radio:last-of-type label {
+    border-radius: 0; } }
+@media all and (min-width: 40em) {
+  .button-group.button-group--vertical_tablet .button--radio:first-of-type label {
+    border-radius: 10px 10px 0 0; }
+  .button-group.button-group--vertical_tablet .button--radio:last-of-type label {
+    border-radius: 0 0 10px 10px; }
+  .button-group.button-group--vertical_tablet.button--smooth .button--radio:first-of-type label, .app-menu .app-context .app-title .button-group.button-group--vertical_tablet.button--navigation .button--radio:first-of-type label {
+    border-radius: 5px 5px 0 0; }
+  .button-group.button-group--vertical_tablet.button--smooth .button--radio:last-of-type label, .app-menu .app-context .app-title .button-group.button-group--vertical_tablet.button--navigation .button--radio:last-of-type label {
+    border-radius: 0 0 5px 5px; }
+  .button-group.button-group--vertical_tablet.button--square .button--radio:first-of-type label, .button-group.button-group--vertical_tablet.button--square .button--radio:last-of-type label {
+    border-radius: 0; } }
+
+.has-tooltip {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none; }
+
+i.dashing-tooltip,
+i.dashing-clippy {
+  cursor: help;
+  display: inline-block; }
+  @media all and (max-width: 40em) {
+    i.dashing-tooltip,
+    i.dashing-clippy {
+      margin: -0.6rem -0.4rem !important;
+      padding: 0.6rem;
+      border-radius: 50px; }
+      i.dashing-tooltip:hover,
+      i.dashing-clippy:hover {
+        background-color: rgba(85, 85, 85, 0.1); } }
+
+span .dashing-tooltip,
+p .dashing-tooltip {
+  margin-left: 0.2rem; }
+
+span.dashing-tooltip {
+  display: inline-block; }
+
+/* Card Styles
+  =========================================================================== */
+.card {
+  background-color: #FFFFFF;
+  border: 2px solid #D4D4D4;
+  border-radius: 10px;
+  margin: 1.5rem auto; }
+  .card .card--header hr, .card.card--content hr, .card.card--footer hr,
+  .card .card-header hr, .card.card-content hr, .card.card-footer hr {
+    margin: 1rem 0; }
+  .card hr {
+    margin: 0; }
+  .card .card--header,
+  .card .card-header {
+    padding: 1rem 1rem 0 1rem;
+    padding-bottom: 0; }
+    .card .card--header.has-border,
+    .card .card-header.has-border {
+      border-bottom: 2px solid #D4D4D4;
+      padding-bottom: 1rem; }
+      .card .card--header.has-border + .card--content .card-banner,
+      .card .card--header.has-border + .card-content .card-banner,
+      .card .card-header.has-border + .card--content .card-banner,
+      .card .card-header.has-border + .card-content .card-banner {
+        margin-top: -1rem; }
+  .card .card--content,
+  .card .card-content {
+    overflow: auto;
+    padding: 1rem; }
+  .card .card--footer,
+  .card .card-footer {
+    padding: 0 1rem 1rem 1rem; }
+    .card .card--footer.has-border,
+    .card .card-footer.has-border {
+      border-top: 2px solid #D4D4D4;
+      padding-top: 1rem; }
+  .card--header + .card.card--footer, .card-header + .card.card-footer {
+    padding-top: 1rem; }
+  .card.is-selectable {
+    transition: box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out; }
+    .card.is-selectable:hover {
+      border-color: #3F70C9;
+      cursor: pointer; }
+  .card.disabled, .card.is-disabled, .card.is-selectable.is-disabled, .card.is-selectable.disabled {
+    opacity: 0.4;
+    pointer-events: none;
+    background-color: #D4D4D4;
+    border-color: #A1A1A1; }
+  .card.card--dashed {
+    border-style: dashed; }
+  .card .card--narrow {
+    max-width: 750px; }
+  .card .card--list, .card .card-list {
+    margin: 0;
+    padding: 0;
+    list-style: none; }
+    .card .card--list li, .card .card-list li {
+      cursor: pointer;
+      padding: 0.75rem;
+      text-align: left;
+      -webkit-transition: all 0.15s ease-in-out;
+      -moz-transition: all 0.15s ease-in-out;
+      -o-transition: all 0.15s ease-in-out;
+      -ms-transition: all 0.15s ease-in-out;
+      transition: all 0.15s ease-in-out; }
+      .card .card--list li:hover, .card .card-list li:hover {
+        background-color: #EDEDED; }
+
+.prevent-scrolling {
+  overflow: hidden; }
+
+.dash-overlay {
+  background-color: rgba(0, 0, 0, 0.8);
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1000; }
+  .dash-overlay.is-locked {
+    overflow: hidden; }
+
+.dash-modal {
+  background-color: #FFFFFF;
+  border-radius: 15px;
+  margin: 1.5rem auto;
+  max-width: 35rem;
+  outline: 0;
+  width: 90%;
+  z-index: 1050;
+  cursor: default;
+  overflow: hidden; }
+  @media all and (min-width: 40em) {
+    .dash-modal {
+      margin: 5rem auto 5rem auto; } }
+  .dash-modal.modal-small {
+    max-width: 25rem; }
+  .dash-modal.modal-large {
+    max-width: 45rem; }
+  .dash-modal .modal-header, .dash-modal .modal-content, .dash-modal .modal-footer {
+    padding: 1rem; }
+    .dash-modal .modal-header hr, .dash-modal .modal-content hr, .dash-modal .modal-footer hr {
+      border: none;
+      border-bottom: 2px solid #E0E0E0;
+      margin: 1rem -1rem; }
+  .dash-modal .modal-close {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+    float: right;
+    font-size: 1.5rem;
+    position: relative;
+    right: .7rem;
+    top: .7rem;
+    cursor: pointer;
+    margin-left: -2rem; }
+  .dash-modal .modal-header {
+    border-bottom: 2px solid #E0E0E0;
+    text-align: center; }
+  .dash-modal .modal-content p {
+    line-height: 1.4rem; }
+  .dash-modal .modal-content.has-video {
+    padding: 0;
+    position: relative;
+    padding-bottom: 56.3%;
+    height: 0;
+    overflow: hidden;
+    max-width: 100%;
+    transform: translateY(0); }
+    .dash-modal .modal-content.has-video iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%; }
+  .dash-modal .modal-footer {
+    background-color: #EDEDED; }
+  .dash-modal .dashing-icon--close:before {
+    color: #555 !important; }
+
+/* Banner Styles
+  =========================================================================== */
+.page-banner {
+  background-color: #E0E0E0;
+  text-align: center;
+  padding: 2rem 1rem;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%; }
+  .page-banner h4 {
+    color: #555555;
+    margin-top: 0.5rem; }
+  .page-banner .button--banner {
+    background-color: #A1A1A1;
+    color: #FFFFFF;
+    position: absolute;
+    top: 2.15rem;
+    right: 1rem; }
+    .page-banner .button--banner:hover, .page-banner .button--banner:focus {
+      background-color: #888888;
+      color: #FFFFFF; }
+    .page-banner .button--banner:active {
+      background-color: #7b7b7b; }
+    .page-banner .button--banner:not(.button--transparent) .dashing-icon:before, .page-banner .button--banner:not(.button--transparent) i.dashing-tooltip:before,
+    .page-banner .button--banner:not(.button--transparent) i.dashing-clippy:before, .page-banner .button--banner:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .page-banner .button--banner:not(.button--transparent) .button--navigation:before {
+      color: #FFFFFF; }
+
+.card-banner {
+  align-items: baseline;
+  background-color: #D4D4D4;
+  display: flex;
+  padding: 1rem;
+  margin: 0 -1rem; }
+  .card-banner.has-button {
+    padding: 0.5rem 1rem;
+    align-items: center; }
+    .card-banner.has-button button {
+      white-space: nowrap; }
+    .card-banner.has-button p {
+      margin-right: 1rem; }
+  .card-banner a {
+    border-bottom: solid 2px;
+    color: inherit;
+    cursor: pointer; }
+    .card-banner a:hover {
+      opacity: 0.6;
+      transition: all 50ms ease-in-out; }
+  .card-banner.has-success p, .card-banner.has-error p {
+    color: #FFFFFF; }
+  .card-banner.has-success .dashing-icon:before, .card-banner.has-success i.dashing-tooltip:before,
+  .card-banner.has-success i.dashing-clippy:before, .card-banner.has-success .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .card-banner.has-success .button--navigation:before, .card-banner.has-error .dashing-icon:before, .card-banner.has-error i.dashing-tooltip:before,
+  .card-banner.has-error i.dashing-clippy:before, .card-banner.has-error .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .card-banner.has-error .button--navigation:before {
+    color: #FFFFFF; }
+  .card-banner.has-warning p {
+    color: #000000; }
+  .card-banner.has-warning .dashing-icon:before, .card-banner.has-warning i.dashing-tooltip:before,
+  .card-banner.has-warning i.dashing-clippy:before, .card-banner.has-warning .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .card-banner.has-warning .button--navigation:before {
+    color: #000000; }
+  .card-banner.has-success {
+    background-color: #09AA66; }
+  .card-banner.has-warning {
+    background-color: #FFA11F; }
+  .card-banner.has-error {
+    background-color: #DA3D30; }
+  .card-banner .dashing-icon, .card-banner i.dashing-tooltip,
+  .card-banner i.dashing-clippy, .card-banner .app-menu .app-context .app-title .button--navigation, .app-menu .app-context .app-title .card-banner .button--navigation {
+    margin-right: 0.5rem; }
+  .card-banner p {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin: 0; }
+
+.table--container .table {
+  background-color: #FFFFFF;
+  font-size: 0.9rem;
+  margin: 0;
+  max-width: 100%;
+  width: 100%; }
+  .table--container .table thead tr {
+    background-color: #FFFFFF; }
+  .table--container .table th, .table--container .table td {
+    padding: 1rem;
+    text-align: left; }
+  .table--container .table td {
+    vertical-align: middle; }
+  .table--container .table th {
+    border-bottom: 2px solid #D4D4D4; }
+
+/* Table States
+  =========================================================================== */
+@media all and (min-width: 40em) {
+  .table--container.has-border {
+    border: 2px solid #D4D4D4;
+    border-radius: 10px;
+    overflow: hidden; } }
+
+.table.has-dividers td,
+.table.has-divider td {
+  border-bottom: 2px solid #EDEDED; }
+.table.has-dividers tr:last-of-type td,
+.table.has-divider tr:last-of-type td {
+  border-bottom: none; }
+
+.table.has-row-color tr:nth-child(odd) {
+  background-color: #F2F2F2; }
+.table.has-row-color tr:nth-child(even) {
+  background-color: #FFFFFF; }
+.table.has-row-color thead tr:nth-child(odd) {
+  background-color: #FFFFFF; }
+.table.has-row-color.has-hover tr:nth-child(odd):hover td {
+  background-color: #e0e0e0; }
+.table.has-row-color.has-hover tr:nth-child(even):hover td {
+  background-color: #ededed; }
+
+.table.has-hover td {
+  -webkit-transition: all 0.15s ease-in-out;
+  -moz-transition: all 0.15s ease-in-out;
+  -o-transition: all 0.15s ease-in-out;
+  -ms-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out; }
+.table.has-hover tr:hover td {
+  background-color: #EDEDED; }
+.table.has-hover tr.disabled:hover td {
+  background-color: transparent;
+  cursor: not-allowed; }
+
+.app-menu {
+  background-color: rgba(237, 237, 237, 0.97);
+  box-shadow: 0 2px 6px #D4D4D4;
+  height: auto !important;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 10; }
+  .app-menu .app-context {
+    max-width: 1200px;
+    margin: auto;
+    padding: 1rem; }
+    .app-menu .app-context .app-title {
+      color: #222222;
+      font-size: 1.25rem;
+      font-weight: 600; }
+      .app-menu .app-context .app-title a {
+        color: #222222; }
+        .app-menu .app-context .app-title a:hover {
+          color: rgba(34, 34, 34, 0.6); }
+        .app-menu .app-context .app-title a.app-title--has-breadcrumb {
+          color: rgba(34, 34, 34, 0.5);
+          cursor: pointer;
+          transition: all 0.2s ease-in-out; }
+          .app-menu .app-context .app-title a.app-title--has-breadcrumb:hover {
+            color: #222222; }
+      .app-menu .app-context .app-title .button--navigation {
+        background-color: #d9d9d9;
+        color: #222222;
+        padding: 0.4rem 0.55rem !important;
+        position: relative;
+        top: -3px;
+        margin-right: 0.5rem;
+        text-decoration: none; }
+        .app-menu .app-context .app-title .button--navigation:hover, .app-menu .app-context .app-title .button--navigation:focus {
+          background-color: #bfbfbf;
+          color: #222222; }
+        .app-menu .app-context .app-title .button--navigation:active {
+          background-color: #b2b2b2; }
+        .app-menu .app-context .app-title .button--navigation:not(.button--transparent) .dashing-icon:before, .app-menu .app-context .app-title .button--navigation:not(.button--transparent) i.dashing-tooltip:before,
+        .app-menu .app-context .app-title .button--navigation:not(.button--transparent) i.dashing-clippy:before, .app-menu .app-context .app-title .button--navigation:not(.button--transparent) .button--navigation:before {
+          color: #FFFFFF; }
+        .app-menu .app-context .app-title .button--navigation:before {
+          content: '\e82a';
+          color: #222222 !important;
+          margin-right: 0.35rem; }
+        .app-menu .app-context .app-title .button--navigation:after {
+          content: 'Back'; }
+    .app-menu .app-context ul.header-description {
+      color: #222222;
+      float: right;
+      position: relative;
+      top: -1.4rem;
+      height: 0;
+      margin: 0;
+      padding: 0;
+      list-style: none; }
+      .app-menu .app-context ul.header-description li {
+        text-align: right;
+        display: inline-block;
+        font-weight: 600;
+        margin-right: 1rem; }
+        .app-menu .app-context ul.header-description li:last-of-type {
+          margin-right: 0; }
+        .app-menu .app-context ul.header-description li .header-description--label,
+        .app-menu .app-context ul.header-description li .header-description--content {
+          display: block; }
+        .app-menu .app-context ul.header-description li .header-description--label {
+          font-size: 0.8rem; }
+        .app-menu .app-context ul.header-description li .header-description--content {
+          font-size: 1.25rem; }
+  .app-menu .app-navigation {
+    max-width: 1200px;
+    margin: auto;
+    overflow: hidden;
+    overflow-x: auto;
+    padding: 0 1rem;
+    white-space: nowrap; }
+    .app-menu .app-navigation li, .app-menu .app-navigation a {
+      border-bottom: 4px solid transparent;
+      padding-bottom: 0.5rem; }
+    .app-menu .app-navigation li {
+      display: inline-block;
+      float: none; }
+      .app-menu .app-navigation li.active a,
+      .app-menu .app-navigation li a.active, .app-menu .app-navigation li.is-active a,
+      .app-menu .app-navigation li a.is-active {
+        color: #222222 !important;
+        border-bottom: 4px solid !important; }
+      .app-menu .app-navigation li a {
+        color: rgba(34, 34, 34, 0.6);
+        font-size: 1rem;
+        line-height: 0.9rem;
+        margin: 0;
+        margin-right: 1.2rem !important;
+        transition: all 0.2s ease-in-out; }
+        .app-menu .app-navigation li a:hover {
+          color: #222222; }
+          .app-menu .app-navigation li a:hover .dashing-icon, .app-menu .app-navigation li a:hover i.dashing-tooltip,
+          .app-menu .app-navigation li a:hover i.dashing-clippy, .app-menu .app-navigation li a:hover .app-context .app-title .button--navigation, .app-menu .app-context .app-title .app-navigation li a:hover .button--navigation {
+            opacity: 1; }
+        .app-menu .app-navigation li a .dashing-icon, .app-menu .app-navigation li a i.dashing-tooltip,
+        .app-menu .app-navigation li a i.dashing-clippy, .app-menu .app-navigation li a .app-context .app-title .button--navigation, .app-menu .app-context .app-title .app-navigation li a .button--navigation {
+          opacity: .6;
+          transition: all 0.2s ease-in-out; }
+  .app-menu .dashing-icon--new-tab:before {
+    color: rgba(34, 34, 34, 0.9); }
+  .app-menu .dashing-icon--arrow-right:before {
+    color: rgba(34, 34, 34, 0.5);
+    font-size: 12px;
+    position: relative;
+    top: -2px; }
+  .app-menu.condensed {
+    height: 4.6rem; }
+  .app-menu.expanded {
+    height: 7.05rem; }
+  .app-menu.fixed {
+    position: fixed; }
+  .app-menu .button--icon--main {
+    position: absolute;
+    right: 1rem;
+    bottom: -1.5rem; }
+    @media screen and (min-width: 1200px) {
+      .app-menu .button--icon--main {
+        right: calc(50% - (1200px/2) - 0.4rem); } }
+
+.app-menu.has-search .app-context {
+  padding: 0.5rem 1rem; }
+  @media all and (min-width: 40em) {
+    .app-menu.has-search .app-context {
+      display: flex;
+      align-items: center; } }
+.app-menu.has-search .app-title {
+  display: inline-block; }
+.app-menu.has-search .search-input {
+  padding-top: 0.5rem; }
+  @media all and (min-width: 40em) {
+    .app-menu.has-search .search-input {
+      margin-left: auto;
+      padding-top: 0rem;
+      width: auto; } }
+.app-menu.has-search fieldset input[type="text"] {
+  border-color: transparent; }
+
+.app-menu.has-search ~ .app-content {
+  padding-top: 5.75rem; }
+  @media all and (min-width: 40em) {
+    .app-menu.has-search ~ .app-content {
+      padding-top: 3.75rem; } }
+
+.app-menu.expanded.has-search ~ .app-content {
+  padding-top: 8rem; }
+  @media all and (min-width: 40em) {
+    .app-menu.expanded.has-search ~ .app-content {
+      padding-top: 5.75rem; } }
+
+.app-menu ~ .app-content {
+  padding-top: 4.6rem; }
+
+.app-menu.expanded ~ .app-content {
+  padding-top: 7.05rem; }
+
+.app-footer {
+  background-color: rgba(255, 255, 255, 0.95);
+  border-top: 2px solid #D4D4D4;
+  box-shadow: 0 -2px 30px 0 rgba(36, 41, 44, 0.15);
+  float: left;
+  max-width: 100%;
+  padding: 1rem;
+  position: absolute;
+  left: 0;
+  width: 100%; }
+  .app-footer.fixed {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0; }
+  .app-footer .row.no-padding {
+    max-width: calc(1200px - 2rem); }
+
+@font-face {
+  font-family: 'dashing-icons';
+  font-weight: normal;
+  font-style: normal; }
+.dashing-icon, i.dashing-tooltip,
+i.dashing-clippy, .app-menu .app-context .app-title .button--navigation {
+  line-height: 0;
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */
+  /* '' */ }
+  .dashing-icon:before, i.dashing-tooltip:before,
+  i.dashing-clippy:before, .app-menu .app-context .app-title .button--navigation:before {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    color: #555555;
+    display: inline-block;
+    font-family: "dashing-icons";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: normal;
+    line-height: 1em;
+    speak: none;
+    text-decoration: inherit;
+    text-align: center;
+    opacity: .9;
+    font-variant: normal;
+    text-transform: none; }
+  .button .dashing-icon, .file-custom .file-custom--button .dashing-icon, button .dashing-icon, input[type='submit'] .dashing-icon, input[type='reset'] .dashing-icon, .app-menu .app-navigation li a .dashing-icon, .button i.dashing-tooltip, .file-custom .file-custom--button i.dashing-tooltip, button i.dashing-tooltip, input[type='submit'] i.dashing-tooltip, input[type='reset'] i.dashing-tooltip, .app-menu .app-navigation li a i.dashing-tooltip,
+  .button i.dashing-clippy,
+  .file-custom .file-custom--button i.dashing-clippy,
+  button i.dashing-clippy,
+  input[type='submit'] i.dashing-clippy,
+  input[type='reset'] i.dashing-clippy,
+  .app-menu .app-navigation li a i.dashing-clippy, .button .app-menu .app-context .app-title .button--navigation, .app-menu .app-context .app-title .button .button--navigation, .file-custom .file-custom--button .app-menu .app-context .app-title .button--navigation, .app-menu .app-context .app-title .file-custom .file-custom--button .button--navigation, button .app-menu .app-context .app-title .button--navigation, .app-menu .app-context .app-title button .button--navigation, input[type='submit'] .app-menu .app-context .app-title .button--navigation, .app-menu .app-context .app-title input[type='submit'] .button--navigation, input[type='reset'] .app-menu .app-context .app-title .button--navigation, .app-menu .app-context .app-title input[type='reset'] .button--navigation, .app-menu .app-navigation li a .app-context .app-title .button--navigation, .app-menu .app-context .app-title .app-navigation li a .button--navigation {
+    display: inline-block;
+    margin-right: 0.2rem;
+    margin-left: -0.2rem; }
+  .button .dashing-icon.flow-opposite, .file-custom .file-custom--button .dashing-icon.flow-opposite, button .dashing-icon.flow-opposite, input[type='submit'] .dashing-icon.flow-opposite, input[type='reset'] .dashing-icon.flow-opposite, .app-menu .app-navigation li a .dashing-icon.flow-opposite, .button i.flow-opposite.dashing-tooltip, .file-custom .file-custom--button i.flow-opposite.dashing-tooltip, button i.flow-opposite.dashing-tooltip, input[type='submit'] i.flow-opposite.dashing-tooltip, input[type='reset'] i.flow-opposite.dashing-tooltip, .app-menu .app-navigation li a i.flow-opposite.dashing-tooltip,
+  .button i.flow-opposite.dashing-clippy,
+  .file-custom .file-custom--button i.flow-opposite.dashing-clippy,
+  button i.flow-opposite.dashing-clippy,
+  input[type='submit'] i.flow-opposite.dashing-clippy,
+  input[type='reset'] i.flow-opposite.dashing-clippy,
+  .app-menu .app-navigation li a i.flow-opposite.dashing-clippy, .button .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title .button .flow-opposite.button--navigation, .file-custom .file-custom--button .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title .file-custom .file-custom--button .flow-opposite.button--navigation, button .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title button .flow-opposite.button--navigation, input[type='submit'] .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title input[type='submit'] .flow-opposite.button--navigation, input[type='reset'] .app-menu .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title input[type='reset'] .flow-opposite.button--navigation, .app-menu .app-navigation li a .app-context .app-title .flow-opposite.button--navigation, .app-menu .app-context .app-title .app-navigation li a .flow-opposite.button--navigation {
+    margin-left: 0.2rem;
+    margin-right: -0.2rem; }
+  .button--icon .dashing-icon, .button--icon i.dashing-tooltip,
+  .button--icon i.dashing-clippy, .button--icon .app-menu .app-context .app-title .button--navigation, .app-menu .app-context .app-title .button--icon .button--navigation {
+    float: left;
+    margin: 0; }
+  .dashing-icon.dashing-icon--white:before, i.dashing-icon--white.dashing-tooltip:before,
+  i.dashing-icon--white.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--white.button--navigation:before {
+    color: #FFFFFF; }
+  .dashing-icon.dashing-icon--black:before, i.dashing-icon--black.dashing-tooltip:before,
+  i.dashing-icon--black.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--black.button--navigation:before {
+    color: #000000; }
+  .dashing-icon.dashing-icon--blue:before, i.dashing-icon--blue.dashing-tooltip:before,
+  i.dashing-icon--blue.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--blue.button--navigation:before {
+    color: #5174BA; }
+  .dashing-icon.dashing-icon--gray:before, i.dashing-tooltip:before,
+  i.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--gray.button--navigation:before, .app-menu .app-context .app-title i.button--navigation.dashing-tooltip:before,
+  .app-menu .app-context .app-title i.button--navigation.dashing-clippy:before, .dashing-icon.dashing-icon--grey:before, i.dashing-icon--grey.dashing-tooltip:before,
+  i.dashing-icon--grey.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--grey.button--navigation:before {
+    color: #6E6E6E; }
+  .dashing-icon.dashing-icon--green:before, i.dashing-icon--green.dashing-tooltip:before,
+  i.dashing-icon--green.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--green.button--navigation:before {
+    color: #09AA66; }
+  .dashing-icon.dashing-icon--orange:before, i.dashing-icon--orange.dashing-tooltip:before,
+  i.dashing-icon--orange.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--orange.button--navigation:before {
+    color: #FFA11F; }
+  .dashing-icon.dashing-icon--red:before, i.dashing-icon--red.dashing-tooltip:before,
+  i.dashing-icon--red.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--red.button--navigation:before {
+    color: #DA3D30; }
+  .dashing-icon.dashing-icon--purple:before, i.dashing-icon--purple.dashing-tooltip:before,
+  i.dashing-icon--purple.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--purple.button--navigation:before {
+    color: #9F65AE; }
+  .dashing-icon.dashing-icon--ui-black:before, i.dashing-icon--ui-black.dashing-tooltip:before,
+  i.dashing-icon--ui-black.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--ui-black.button--navigation:before {
+    color: #40464C; }
+  .dashing-icon.dashing-icon--ui-blue:before, i.dashing-icon--ui-blue.dashing-tooltip:before,
+  i.dashing-icon--ui-blue.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--ui-blue.button--navigation:before {
+    color: #3F70C9; }
+  .dashing-icon.dashing-icon--ui-green:before, i.dashing-icon--ui-green.dashing-tooltip:before,
+  i.dashing-icon--ui-green.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--ui-green.button--navigation:before {
+    color: #09AA66; }
+  .dashing-icon.dashing-icon--ui-red:before, i.dashing-icon--ui-red.dashing-tooltip:before,
+  i.dashing-icon--ui-red.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--ui-red.button--navigation:before {
+    color: #DA3D30; }
+  .dashing-icon.dashing-icon--ui-orange:before, i.dashing-icon--ui-orange.dashing-tooltip:before,
+  i.dashing-icon--ui-orange.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--ui-orange.button--navigation:before {
+    color: #FFA11F; }
+  .dashing-icon.dashing-icon--brand-purple:before, i.dashing-icon--brand-purple.dashing-tooltip:before,
+  i.dashing-icon--brand-purple.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--brand-purple.button--navigation:before {
+    color: #9F65AE; }
+  .dashing-icon.dashing-icon--arrow-down:before, i.dashing-icon--arrow-down.dashing-tooltip:before,
+  i.dashing-icon--arrow-down.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--arrow-down.button--navigation:before {
+    content: '\e800'; }
+  .dashing-icon.dashing-icon--calendar:before, i.dashing-icon--calendar.dashing-tooltip:before,
+  i.dashing-icon--calendar.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--calendar.button--navigation:before {
+    content: '\e801'; }
+  .dashing-icon.dashing-icon--checkmark-filled:before, i.dashing-icon--checkmark-filled.dashing-tooltip:before,
+  i.dashing-icon--checkmark-filled.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--checkmark-filled.button--navigation:before {
+    content: '\e802'; }
+  .dashing-icon.dashing-icon--checkmark-stroke:before, i.dashing-icon--checkmark-stroke.dashing-tooltip:before,
+  i.dashing-icon--checkmark-stroke.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--checkmark-stroke.button--navigation:before {
+    content: '\e803'; }
+  .dashing-icon.dashing-icon--close:before, i.dashing-icon--close.dashing-tooltip:before,
+  i.dashing-icon--close.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--close.button--navigation:before {
+    content: '\e804'; }
+  .dashing-icon.dashing-icon--comment-add:before, i.dashing-icon--comment-add.dashing-tooltip:before,
+  i.dashing-icon--comment-add.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--comment-add.button--navigation:before {
+    content: '\e806'; }
+  .dashing-icon.dashing-icon--comment:before, i.dashing-icon--comment.dashing-tooltip:before,
+  i.dashing-icon--comment.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--comment.button--navigation:before {
+    content: '\e807'; }
+  .dashing-icon.dashing-icon--do-not-pull:before, i.dashing-icon--do-not-pull.dashing-tooltip:before,
+  i.dashing-icon--do-not-pull.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--do-not-pull.button--navigation:before {
+    content: '\e808'; }
+  .dashing-icon.dashing-icon--do-not-push:before, i.dashing-icon--do-not-push.dashing-tooltip:before,
+  i.dashing-icon--do-not-push.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--do-not-push.button--navigation:before {
+    content: '\e809'; }
+  .dashing-icon.dashing-icon--fit-page:before, i.dashing-icon--fit-page.dashing-tooltip:before,
+  i.dashing-icon--fit-page.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--fit-page.button--navigation:before {
+    content: '\e80a'; }
+  .dashing-icon.dashing-icon--fit-width:before, i.dashing-icon--fit-width.dashing-tooltip:before,
+  i.dashing-icon--fit-width.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--fit-width.button--navigation:before {
+    content: '\e80b'; }
+  .dashing-icon.dashing-icon--flip:before, i.dashing-icon--flip.dashing-tooltip:before,
+  i.dashing-icon--flip.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--flip.button--navigation:before {
+    content: '\e80c'; }
+  .dashing-icon.dashing-icon--hidden:before, i.dashing-icon--hidden.dashing-tooltip:before,
+  i.dashing-icon--hidden.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--hidden.button--navigation:before {
+    content: '\e80d'; }
+  .dashing-icon.dashing-icon--info:before, i.dashing-icon--info.dashing-tooltip:before,
+  i.dashing-icon--info.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--info.button--navigation:before {
+    content: '\e80e'; }
+  .dashing-icon.dashing-icon--info-filled:before, i.dashing-icon--info-filled.dashing-tooltip:before,
+  i.dashing-icon--info-filled.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--info-filled.button--navigation:before {
+    content: '\e80f'; }
+  .dashing-icon.dashing-icon--info-stroke:before, i.dashing-icon--info-stroke.dashing-tooltip:before,
+  i.dashing-icon--info-stroke.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--info-stroke.button--navigation:before {
+    content: '\e810'; }
+  .dashing-icon.dashing-icon--location:before, i.dashing-icon--location.dashing-tooltip:before,
+  i.dashing-icon--location.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--location.button--navigation:before {
+    content: '\e811'; }
+  .dashing-icon.dashing-icon--locked:before, i.dashing-icon--locked.dashing-tooltip:before,
+  i.dashing-icon--locked.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--locked.button--navigation:before {
+    content: '\e812'; }
+  .dashing-icon.dashing-icon--minus:before, i.dashing-icon--minus.dashing-tooltip:before,
+  i.dashing-icon--minus.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--minus.button--navigation:before, .dashing-icon.dashing-icon--zoom-out:before, i.dashing-icon--zoom-out.dashing-tooltip:before,
+  i.dashing-icon--zoom-out.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--zoom-out.button--navigation:before {
+    content: '\e814'; }
+  .dashing-icon.dashing-icon--new-tab:before, i.dashing-icon--new-tab.dashing-tooltip:before,
+  i.dashing-icon--new-tab.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--new-tab.button--navigation:before {
+    content: '\e815'; }
+  .dashing-icon.dashing-icon--notification:before, i.dashing-icon--notification.dashing-tooltip:before,
+  i.dashing-icon--notification.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--notification.button--navigation:before {
+    content: '\e816'; }
+  .dashing-icon.dashing-icon--page:before, i.dashing-icon--page.dashing-tooltip:before,
+  i.dashing-icon--page.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--page.button--navigation:before {
+    content: '\e817'; }
+  .dashing-icon.dashing-icon--pencil:before, i.dashing-icon--pencil.dashing-tooltip:before,
+  i.dashing-icon--pencil.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--pencil.button--navigation:before {
+    content: '\e818'; }
+  .dashing-icon.dashing-icon--phone:before, i.dashing-icon--phone.dashing-tooltip:before,
+  i.dashing-icon--phone.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--phone.button--navigation:before {
+    content: '\e819'; }
+  .dashing-icon.dashing-icon--play:before, i.dashing-icon--play.dashing-tooltip:before,
+  i.dashing-icon--play.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--play.button--navigation:before {
+    content: '\e81b'; }
+  .dashing-icon.dashing-icon--plus:before, i.dashing-icon--plus.dashing-tooltip:before,
+  i.dashing-icon--plus.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--plus.button--navigation:before, .dashing-icon.dashing-icon--add:before, i.dashing-icon--add.dashing-tooltip:before,
+  i.dashing-icon--add.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--add.button--navigation:before, .dashing-icon.dashing-icon--zoom-in:before, i.dashing-icon--zoom-in.dashing-tooltip:before,
+  i.dashing-icon--zoom-in.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--zoom-in.button--navigation:before {
+    content: '\e81c'; }
+  .dashing-icon.dashing-icon--pull:before, i.dashing-icon--pull.dashing-tooltip:before,
+  i.dashing-icon--pull.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--pull.button--navigation:before {
+    content: '\e81d'; }
+  .dashing-icon.dashing-icon--push:before, i.dashing-icon--push.dashing-tooltip:before,
+  i.dashing-icon--push.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--push.button--navigation:before {
+    content: '\e81e'; }
+  .dashing-icon.dashing-icon--question-filled:before, i.dashing-tooltip:before,
+  i.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--question-filled.button--navigation:before, .app-menu .app-context .app-title i.button--navigation.dashing-tooltip:before,
+  .app-menu .app-context .app-title i.button--navigation.dashing-clippy:before {
+    content: '\e81f'; }
+  .dashing-icon.dashing-icon--quicknav:before, i.dashing-icon--quicknav.dashing-tooltip:before,
+  i.dashing-icon--quicknav.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--quicknav.button--navigation:before, .dashing-icon.dashing-icon--grid:before, i.dashing-icon--grid.dashing-tooltip:before,
+  i.dashing-icon--grid.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--grid.button--navigation:before {
+    content: '\e820'; }
+  .dashing-icon.dashing-icon--reply:before, i.dashing-icon--reply.dashing-tooltip:before,
+  i.dashing-icon--reply.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--reply.button--navigation:before {
+    content: '\e821'; }
+  .dashing-icon.dashing-icon--rotate:before, i.dashing-icon--rotate.dashing-tooltip:before,
+  i.dashing-icon--rotate.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--rotate.button--navigation:before {
+    content: '\e822'; }
+  .dashing-icon.dashing-icon--search:before, i.dashing-icon--search.dashing-tooltip:before,
+  i.dashing-icon--search.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--search.button--navigation:before {
+    content: '\e823'; }
+  .dashing-icon.dashing-icon--settings:before, i.dashing-icon--settings.dashing-tooltip:before,
+  i.dashing-icon--settings.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--settings.button--navigation:before {
+    content: '\e824'; }
+  .dashing-icon.dashing-icon--show:before, i.dashing-icon--show.dashing-tooltip:before,
+  i.dashing-icon--show.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--show.button--navigation:before {
+    content: '\e825'; }
+  .dashing-icon.dashing-icon--time:before, i.dashing-icon--time.dashing-tooltip:before,
+  i.dashing-icon--time.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--time.button--navigation:before {
+    content: '\e826'; }
+  .dashing-icon.dashing-icon--trash:before, i.dashing-icon--trash.dashing-tooltip:before,
+  i.dashing-icon--trash.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--trash.button--navigation:before {
+    content: '\e827'; }
+  .dashing-icon.dashing-icon--unlocked:before, i.dashing-icon--unlocked.dashing-tooltip:before,
+  i.dashing-icon--unlocked.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--unlocked.button--navigation:before {
+    content: '\e828'; }
+  .dashing-icon.dashing-icon--view-double:before, i.dashing-icon--view-double.dashing-tooltip:before,
+  i.dashing-icon--view-double.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--view-double.button--navigation:before {
+    content: '\e829'; }
+  .dashing-icon.dashing-icon--arrow-left:before, i.dashing-icon--arrow-left.dashing-tooltip:before,
+  i.dashing-icon--arrow-left.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--arrow-left.button--navigation:before {
+    content: '\e82a'; }
+  .dashing-icon.dashing-icon--arrow-long-down:before, i.dashing-icon--arrow-long-down.dashing-tooltip:before,
+  i.dashing-icon--arrow-long-down.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--arrow-long-down.button--navigation:before {
+    content: '\e82b'; }
+  .dashing-icon.dashing-icon--arrow-long-left:before, i.dashing-icon--arrow-long-left.dashing-tooltip:before,
+  i.dashing-icon--arrow-long-left.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--arrow-long-left.button--navigation:before {
+    content: '\e82c'; }
+  .dashing-icon.dashing-icon--arrow-long-up:before, i.dashing-icon--arrow-long-up.dashing-tooltip:before,
+  i.dashing-icon--arrow-long-up.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--arrow-long-up.button--navigation:before {
+    content: '\e82d'; }
+  .dashing-icon.dashing-icon--arrow-right:before, i.dashing-icon--arrow-right.dashing-tooltip:before,
+  i.dashing-icon--arrow-right.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--arrow-right.button--navigation:before {
+    content: '\e82e'; }
+  .dashing-icon.dashing-icon--arrow-up:before, i.dashing-icon--arrow-up.dashing-tooltip:before,
+  i.dashing-icon--arrow-up.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--arrow-up.button--navigation:before {
+    content: '\e82f'; }
+  .dashing-icon.dashing-icon--heart:before, i.dashing-icon--heart.dashing-tooltip:before,
+  i.dashing-icon--heart.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--heart.button--navigation:before {
+    content: '\e832'; }
+  .dashing-icon.dashing-icon--question-stroke:before, i.dashing-icon--question-stroke.dashing-tooltip:before,
+  i.dashing-icon--question-stroke.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--question-stroke.button--navigation:before {
+    content: '\e833'; }
+  .dashing-icon.dashing-icon--view-single:before, i.dashing-icon--view-single.dashing-tooltip:before,
+  i.dashing-icon--view-single.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--view-single.button--navigation:before {
+    content: '\e834'; }
+  .dashing-icon.dashing-icon--checkmark:before, i.dashing-icon--checkmark.dashing-tooltip:before,
+  i.dashing-icon--checkmark.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--checkmark.button--navigation:before {
+    content: '\e835'; }
+  .dashing-icon.dashing-icon--arrow-long-right:before, i.dashing-icon--arrow-long-right.dashing-tooltip:before,
+  i.dashing-icon--arrow-long-right.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--arrow-long-right.button--navigation:before {
+    content: '\e836'; }
+  .dashing-icon.dashing-icon--alert-stroke:before, i.dashing-icon--alert-stroke.dashing-tooltip:before,
+  i.dashing-icon--alert-stroke.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--alert-stroke.button--navigation:before {
+    content: '\e837'; }
+  .dashing-icon.dashing-icon--alert-filled:before, i.dashing-icon--alert-filled.dashing-tooltip:before,
+  i.dashing-icon--alert-filled.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--alert-filled.button--navigation:before {
+    content: '\e838'; }
+  .dashing-icon.dashing-icon--add-person:before, i.dashing-icon--add-person.dashing-tooltip:before,
+  i.dashing-icon--add-person.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--add-person.button--navigation:before {
+    content: '\e839'; }
+  .dashing-icon.dashing-icon--inbox:before, i.dashing-icon--inbox.dashing-tooltip:before,
+  i.dashing-icon--inbox.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--inbox.button--navigation:before {
+    content: '\e83d'; }
+  .dashing-icon.dashing-icon--face-amazing:before, i.dashing-icon--face-amazing.dashing-tooltip:before,
+  i.dashing-icon--face-amazing.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--face-amazing.button--navigation:before {
+    content: '\e83e'; }
+  .dashing-icon.dashing-icon--face-awful:before, i.dashing-icon--face-awful.dashing-tooltip:before,
+  i.dashing-icon--face-awful.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--face-awful.button--navigation:before {
+    content: '\e83f'; }
+  .dashing-icon.dashing-icon--face-ok:before, i.dashing-icon--face-ok.dashing-tooltip:before,
+  i.dashing-icon--face-ok.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--face-ok.button--navigation:before {
+    content: '\e840'; }
+  .dashing-icon.dashing-icon--face-good:before, i.dashing-icon--face-good.dashing-tooltip:before,
+  i.dashing-icon--face-good.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--face-good.button--navigation:before {
+    content: '\e841'; }
+  .dashing-icon.dashing-icon--face-bad:before, i.dashing-icon--face-bad.dashing-tooltip:before,
+  i.dashing-icon--face-bad.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--face-bad.button--navigation:before {
+    content: '\e842'; }
+  .dashing-icon.dashing-icon--mobile-phone:before, i.dashing-icon--mobile-phone.dashing-tooltip:before,
+  i.dashing-icon--mobile-phone.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--mobile-phone.button--navigation:before {
+    content: '\e844'; }
+  .dashing-icon.dashing-icon--notification-off:before, i.dashing-icon--notification-off.dashing-tooltip:before,
+  i.dashing-icon--notification-off.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--notification-off.button--navigation:before {
+    content: '\e845'; }
+  .dashing-icon.dashing-icon--star-stroke:before, i.dashing-icon--star-stroke.dashing-tooltip:before,
+  i.dashing-icon--star-stroke.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--star-stroke.button--navigation:before {
+    content: '\e847'; }
+  .dashing-icon.dashing-icon--star-filled:before, i.dashing-icon--star-filled.dashing-tooltip:before,
+  i.dashing-icon--star-filled.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--star-filled.button--navigation:before, .dashing-icon.dashing-icon--star:before, i.dashing-icon--star.dashing-tooltip:before,
+  i.dashing-icon--star.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--star.button--navigation:before {
+    content: '\e831'; }
+  .dashing-icon.dashing-icon--menu:before, i.dashing-icon--menu.dashing-tooltip:before,
+  i.dashing-icon--menu.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--menu.button--navigation:before {
+    content: '\e849'; }
+  .dashing-icon.dashing-icon--categories:before, i.dashing-icon--categories.dashing-tooltip:before,
+  i.dashing-icon--categories.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--categories.button--navigation:before {
+    content: '\e84a'; }
+  .dashing-icon.dashing-icon--mail:before, i.dashing-icon--mail.dashing-tooltip:before,
+  i.dashing-icon--mail.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--mail.button--navigation:before {
+    content: '\e81a'; }
+  .dashing-icon.dashing-icon--chat-filled:before, i.dashing-icon--chat-filled.dashing-tooltip:before,
+  i.dashing-icon--chat-filled.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--chat-filled.button--navigation:before {
+    content: '\e813'; }
+  .dashing-icon.dashing-icon--popular:before, i.dashing-icon--popular.dashing-tooltip:before,
+  i.dashing-icon--popular.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--popular.button--navigation:before {
+    content: '\e830'; }
+  .dashing-icon.dashing-icon--paper-check:before, i.dashing-icon--paper-check.dashing-tooltip:before,
+  i.dashing-icon--paper-check.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--paper-check.button--navigation:before {
+    content: '\e83a'; }
+  .dashing-icon.dashing-icon--paper-check-2:before, i.dashing-icon--paper-check-2.dashing-tooltip:before,
+  i.dashing-icon--paper-check-2.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--paper-check-2.button--navigation:before {
+    content: '\e805'; }
+  .dashing-icon.dashing-icon--pause:before, i.dashing-icon--pause.dashing-tooltip:before,
+  i.dashing-icon--pause.dashing-clippy:before, .app-menu .app-context .app-title .dashing-icon--pause.button--navigation:before {
+    content: '\e846'; }
+
+.dash-spinner, .has-spinner:after, .button.has-spinner:after, .file-custom .has-spinner.file-custom--button:after {
+  -webkit-animation: rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);
+  -moz-animation: rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);
+  -ms-animation: rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);
+  -o-animation: rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);
+  animation: rotation 1250ms infinite cubic-bezier(0.75, 0.28, 0.44, 0.82);
+  position: relative;
+  border-radius: 100%;
+  border: 6px solid rgba(0, 0, 0, 0.15);
+  border-top: 6px solid black;
+  float: left;
+  height: 90px;
+  width: 90px;
+  top: calc(50% - (90px/2));
+  left: calc(50% - (90px/2)); }
+  .dash-spinner.small, .small.has-spinner:after {
+    border-width: 3px;
+    height: 32px;
+    width: 32px;
+    top: calc(50% - (32px/2));
+    left: calc(50% - (32px/2)); }
+
+.has-spinner {
+  background-color: #f2f2f2;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10; }
+  .has-spinner:after {
+    content: "";
+    position: absolute; }
+
+.button.has-spinner, .file-custom .has-spinner.file-custom--button {
+  pointer-events: none;
+  color: transparent;
+  position: relative; }
+  .button.has-spinner:hover, .file-custom .has-spinner.file-custom--button:hover, .button.has-spinner:active, .file-custom .has-spinner.file-custom--button:active, .button.has-spinner:focus, .file-custom .has-spinner.file-custom--button:focus {
+    color: transparent; }
+  .button.has-spinner:after, .file-custom .has-spinner.file-custom--button:after {
+    content: "";
+    border-width: 3px;
+    border-color: rgba(255, 255, 255, 0.15);
+    border-top-color: white;
+    position: absolute;
+    height: 24px;
+    width: 24px;
+    top: calc(50% - (24px/2));
+    left: calc(50% - (24px/2)); }
+
+@-webkit-keyframes rotation {
+  from {
+    -webkit-transform: rotate(0deg); }
+  to {
+    -webkit-transform: rotate(359deg); } }
+@-moz-keyframes rotation {
+  from {
+    -moz-transform: rotate(0deg); }
+  to {
+    -moz-transform: rotate(359deg); } }
+@-o-keyframes rotation {
+  from {
+    -o-transform: rotate(0deg); }
+  to {
+    -o-transform: rotate(359deg); } }
+@keyframes rotation {
+  from {
+    transform: rotate(0deg); }
+  to {
+    transform: rotate(359deg); } }
+/* Tag Variables
+  =========================================================================== */
+/* Tag Extendables
+  =========================================================================== */
+.tag {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+  background-color: #E0E0E0;
+  border-radius: 3px;
+  border: 2px solid #E0E0E0;
+  color: #3F70C9;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  min-width: 1rem;
+  padding: 0.1rem 0.25rem;
+  text-transform: uppercase;
+  margin: 0.25rem; }
+  .tag:not(.tag--no-link):hover, .tag:not(.tag--no-link):focus {
+    border: 2px solid #3F70C9;
+    color: #3F70C9;
+    transition: border-color .1s ease-in-out; }
+
+/* Tag Styles
+  =========================================================================== */
+.tag.tag--no-link {
+  opacity: 1;
+  cursor: initial; }
+.tag.tag--large {
+  font-size: 1rem; }
+.tag.tag--primary, .tag.tag--blue {
+  background-color: #E0E0E0;
+  border-color: #E0E0E0;
+  color: #3F70C9; }
+  .tag.tag--primary:not(.tag--no-link):hover, .tag.tag--primary:not(.tag--no-link):focus, .tag.tag--blue:not(.tag--no-link):hover, .tag.tag--blue:not(.tag--no-link):focus {
+    border-color: #3F70C9;
+    color: #678ed4; }
+.tag.tag--secondary, .tag.tag--gray, .tag.tag--grey {
+  background-color: #E0E0E0;
+  border-color: #E0E0E0;
+  color: #3B3B3B; }
+  .tag.tag--secondary:not(.tag--no-link):hover, .tag.tag--secondary:not(.tag--no-link):focus, .tag.tag--gray:not(.tag--no-link):hover, .tag.tag--gray:not(.tag--no-link):focus, .tag.tag--grey:not(.tag--no-link):hover, .tag.tag--grey:not(.tag--no-link):focus {
+    border-color: #3B3B3B;
+    color: #555555; }
+.tag.tag--green {
+  background-color: #E0E0E0;
+  border-color: #E0E0E0;
+  color: #149853; }
+  .tag.tag--green:not(.tag--no-link):hover, .tag.tag--green:not(.tag--no-link):focus {
+    border-color: #149853;
+    color: #1ac56c; }
+.tag.tag--orange {
+  background-color: #E0E0E0;
+  border-color: #E0E0E0;
+  color: #C47A18; }
+  .tag.tag--orange:not(.tag--no-link):hover, .tag.tag--orange:not(.tag--no-link):focus {
+    border-color: #C47A18;
+    color: #e5952a; }
+.tag.tag--purple {
+  background-color: #E0E0E0;
+  border-color: #E0E0E0;
+  color: #9F65AE; }
+  .tag.tag--purple:not(.tag--no-link):hover, .tag.tag--purple:not(.tag--no-link):focus {
+    border-color: #9F65AE;
+    color: #b486c0; }
+.tag.tag--red {
+  background-color: #E0E0E0;
+  border-color: #E0E0E0;
+  color: #DA3D30; }
+  .tag.tag--red:not(.tag--no-link):hover, .tag.tag--red:not(.tag--no-link):focus {
+    border-color: #DA3D30;
+    color: #e2665b; }
+.tag.tag--white {
+  background-color: #E0E0E0;
+  border-color: #E0E0E0;
+  color: #FFFFFF; }
+  .tag.tag--white:not(.tag--no-link):hover, .tag.tag--white:not(.tag--no-link):focus {
+    border-color: #FFFFFF;
+    color: white; }
+.tag.tag--black {
+  background-color: #E0E0E0;
+  border-color: #E0E0E0;
+  color: #40464C; }
+  .tag.tag--black:not(.tag--no-link):hover, .tag.tag--black:not(.tag--no-link):focus {
+    border-color: #40464C;
+    color: #576068; }
+
+.tag--solid.tag--primary, .tag--solid.tag--blue {
+  background-color: #3F70C9;
+  border-color: #3F70C9;
+  color: #FFFFFF; }
+  .tag--solid.tag--primary:not(.tag--no-link):hover, .tag--solid.tag--primary:not(.tag--no-link):focus, .tag--solid.tag--blue:not(.tag--no-link):hover, .tag--solid.tag--blue:not(.tag--no-link):focus {
+    border-color: #24447e;
+    color: white; }
+.tag--solid.tag--secondary, .tag--solid.tag--grey, .tag--solid.tag--gray {
+  background-color: #D4D4D4;
+  border-color: #D4D4D4;
+  color: #24292C; }
+  .tag--solid.tag--secondary:not(.tag--no-link):hover, .tag--solid.tag--secondary:not(.tag--no-link):focus, .tag--solid.tag--grey:not(.tag--no-link):hover, .tag--solid.tag--grey:not(.tag--no-link):focus, .tag--solid.tag--gray:not(.tag--no-link):hover, .tag--solid.tag--gray:not(.tag--no-link):focus {
+    border-color: #a1a1a1;
+    color: #3b4348; }
+.tag--solid.tag--green {
+  background-color: #09AA66;
+  border-color: #09AA66;
+  color: #FFFFFF; }
+  .tag--solid.tag--green:not(.tag--no-link):hover, .tag--solid.tag--green:not(.tag--no-link):focus {
+    border-color: #04492c;
+    color: white; }
+.tag--solid.tag--orange {
+  background-color: #FFA11F;
+  border-color: #FFA11F;
+  color: #24292C; }
+  .tag--solid.tag--orange:not(.tag--no-link):hover, .tag--solid.tag--orange:not(.tag--no-link):focus {
+    border-color: #b86b00;
+    color: #3b4348; }
+.tag--solid.tag--purple {
+  background-color: #9F65AE;
+  border-color: #9F65AE;
+  color: #FFFFFF; }
+  .tag--solid.tag--purple:not(.tag--no-link):hover, .tag--solid.tag--purple:not(.tag--no-link):focus {
+    border-color: #663c71;
+    color: white; }
+.tag--solid.tag--red {
+  background-color: #DA3D30;
+  border-color: #DA3D30;
+  color: #FFFFFF; }
+  .tag--solid.tag--red:not(.tag--no-link):hover, .tag--solid.tag--red:not(.tag--no-link):focus {
+    border-color: #8b2219;
+    color: white; }
+.tag--solid.tag--white {
+  background-color: #FFFFFF;
+  border-color: #FFFFFF;
+  color: #24292C; }
+  .tag--solid.tag--white:not(.tag--no-link):hover, .tag--solid.tag--white:not(.tag--no-link):focus {
+    border-color: #cccccc;
+    color: #3b4348; }
+
+.tag--counter {
+  display: inline-block;
+  background-color: transparent; }
+  .tag--counter.tag--no-link {
+    opacity: 1;
+    cursor: initial; }
+  .tag--counter:not(.tag--no-link):hover .tag, .tag--counter:not(.tag--no-link):focus .tag {
+    border-color: #3F70C9;
+    transition: border-color .1s ease-in-out; }
+    .tag--counter:not(.tag--no-link):hover .tag.tag--primary, .tag--counter:not(.tag--no-link):hover .tag.tag--blue, .tag--counter:not(.tag--no-link):focus .tag.tag--primary, .tag--counter:not(.tag--no-link):focus .tag.tag--blue {
+      border-color: #24447e; }
+    .tag--counter:not(.tag--no-link):hover .tag.tag--secondary, .tag--counter:not(.tag--no-link):hover .tag.tag--grey, .tag--counter:not(.tag--no-link):hover .tag.tag--gray, .tag--counter:not(.tag--no-link):focus .tag.tag--secondary, .tag--counter:not(.tag--no-link):focus .tag.tag--grey, .tag--counter:not(.tag--no-link):focus .tag.tag--gray {
+      border-color: #a1a1a1; }
+    .tag--counter:not(.tag--no-link):hover .tag.tag--green, .tag--counter:not(.tag--no-link):focus .tag.tag--green {
+      border-color: #04492c; }
+    .tag--counter:not(.tag--no-link):hover .tag.tag--orange, .tag--counter:not(.tag--no-link):focus .tag.tag--orange {
+      border-color: #b86b00; }
+    .tag--counter:not(.tag--no-link):hover .tag.tag--purple, .tag--counter:not(.tag--no-link):focus .tag.tag--purple {
+      border-color: #663c71; }
+    .tag--counter:not(.tag--no-link):hover .tag.tag--red, .tag--counter:not(.tag--no-link):focus .tag.tag--red {
+      border-color: #8b2219; }
+    .tag--counter:not(.tag--no-link):hover .tag.tag--white, .tag--counter:not(.tag--no-link):focus .tag.tag--white {
+      border-color: #cccccc; }
+  .tag--counter .tag:first-child {
+    border-radius: 3px 0 0 3px;
+    border-right: transparent;
+    margin-right: 0; }
+  .tag--counter .tag:last-child {
+    border-radius: 0 3px 3px 0;
+    background-color: #FFFFFF;
+    color: #3B3B3B;
+    border-left: transparent;
+    margin-left: 0; }
+    .tag--counter .tag:last-child:not(.tag--no-link):hover, .tag--counter .tag:last-child:not(.tag--no-link):focus {
+      color: #3B3B3B; }
+
+.tag.plan-11 {
+  background-color: #FFA11F;
+  border-color: #FFA11F;
+  color: #000000; }
+  .tag.plan-11:not(.tag--no-link):hover, .tag.plan-11:not(.tag--no-link):focus {
+    border-color: #b86b00;
+    color: #1a1a1a; }
+
+.tag--counter:not(.tag--no-link):hover .tag.plan-11, .tag--counter:not(.tag--no-link):focus .tag.plan-11 {
+  border-color: #b86b00; }
+
+.plan-1.tag {
+  background-color: #8560A8;
+  border-color: #8560A8;
+  color: #FFFFFF; }
+  .plan-1.tag:not(.tag--no-link):hover, .plan-1.tag:not(.tag--no-link):focus {
+    border-color: #523969;
+    color: white; }
+
+.tag--counter:not(.tag--no-link):hover .tag.plan-1, .tag--counter:not(.tag--no-link):focus .tag.plan-1 {
+  border-color: #523969; }
+
+.plan-0.tag {
+  background-color: #09AA66;
+  border-color: #09AA66;
+  color: #FFFFFF; }
+  .plan-0.tag:not(.tag--no-link):hover, .plan-0.tag:not(.tag--no-link):focus {
+    border-color: #04492c;
+    color: white; }
+
+.tag--counter:not(.tag--no-link):hover .tag.plan-0, .tag--counter:not(.tag--no-link):focus .tag.plan-0 {
+  border-color: #04492c; }
+
+.progress-container {
+  margin: auto;
+  max-width: 750px;
+  padding: 2rem 1rem; }
+
+.progress {
+  background-color: #E0E0E0;
+  border-radius: 15px;
+  height: 15px;
+  width: 100%;
+  overflow: hidden; }
+  .progress .progress-bar {
+    border-radius: 15px;
+    height: 100%;
+    background-color: #09AA66; }
+
+.progress-labels {
+  display: flex; }
+
+.progress-label,
+.progress-label a {
+  color: #6E6E6E;
+  display: flex;
+  padding: 0;
+  padding-top: 0.5rem;
+  flex-grow: 1;
+  font-size: 0.8rem;
+  font-weight: 600;
+  justify-content: center;
+  text-align: center; }
+  @media all and (min-width: 40em) {
+    .progress-label,
+    .progress-label a {
+      font-size: 0.9rem; } }
+  .progress-label.progress-label--completed, .progress-label.progress-label--completed a,
+  .progress-label a.progress-label--completed,
+  .progress-label a.progress-label--completed a {
+    color: #09AA66; }
+
+.progress-bar--1of2 {
+  width: calc(1/4 * 100%); }
+
+.progress-bar--2of2 {
+  width: calc(3/4 * 100%); }
+
+.progress-bar--1of3 {
+  width: calc(1/6 * 100%); }
+
+.progress-bar--2of3 {
+  width: calc(3/6 * 100%); }
+
+.progress-bar--3of3 {
+  width: calc(5/6 * 100%); }
+
+.progress-bar--1of4 {
+  width: calc(1/8 * 100%); }
+
+.progress-bar--2of4 {
+  width: calc(3/8 * 100%); }
+
+.progress-bar--3of4 {
+  width: calc(5/8 * 100%); }
+
+.progress-bar--4of4 {
+  width: calc(7/8 * 100%); }
+
+.progress-bar--completed {
+  width: 100%; }
+
+.ordered-list--custom {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  counter-reset: step-counter;
+  /* Sets a counter named 'step-counter' and sets value to 0 */ }
+  .ordered-list--custom li {
+    counter-increment: step-counter;
+    /* Increments 'step-counter' variable */
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: baseline; }
+    .ordered-list--custom li::before {
+      content: counter(step-counter);
+      /* Displays the value of 'step-counter' */
+      margin-right: 0.5rem;
+      font-size: 1rem;
+      background-color: #D4D4D4;
+      color: #000000;
+      font-weight: 600;
+      padding: .3rem .7rem;
+      border-radius: 50%; }
+    .ordered-list--custom li:last-of-type {
+      margin-bottom: 0; }
+  .ordered-list--custom > *:not(li) {
+    /* Indent all content within <ol> to line up with the <li> */
+    text-indent: 2.5rem; }
+  .ordered-list--custom.ordered-list--sharing-blue li::before {
+    background-color: #71B9E0;
+    color: #FFFFFF; }
+
 /*# sourceMappingURL=dashing.css.map */

--- a/dashing.css
+++ b/dashing.css
@@ -930,10 +930,10 @@ corresponds to the arrow we want to display */
 
 /* Action Extendables
   =========================================================================== */
-.button, .file-custom .file-custom--button, button, input[type='submit'], input[type='reset'], .button.button--round, button.button--round, input[type='submit'].button--round, input[type='reset'].button--round {
+.button.button--round, .file-custom .button--round.file-custom--button, button.button--round, input[type='submit'].button--round, input[type='reset'].button--round {
   border-radius: 50px; }
 
-.button.button--smooth, .file-custom .button--smooth.file-custom--button, .file-custom .app-menu .app-context .app-title .file-custom--button.button--navigation, .app-menu .app-context .app-title .file-custom .file-custom--button.button--navigation, .app-menu .app-context .app-title .button.button--navigation, button.button--smooth, .app-menu .app-context .app-title button.button--navigation, input[type='submit'].button--smooth, .app-menu .app-context .app-title input[type='submit'].button--navigation, input[type='reset'].button--smooth, .app-menu .app-context .app-title input[type='reset'].button--navigation, .page-banner .button--banner {
+.button, .file-custom .file-custom--button, button, input[type='submit'], input[type='reset'], .button.button--smooth, .file-custom .app-menu .app-context .app-title .file-custom--button.button--navigation, .app-menu .app-context .app-title .file-custom .file-custom--button.button--navigation, .app-menu .app-context .app-title .button.button--navigation, button.button--smooth, .app-menu .app-context .app-title button.button--navigation, input[type='submit'].button--smooth, .app-menu .app-context .app-title input[type='submit'].button--navigation, input[type='reset'].button--smooth, .app-menu .app-context .app-title input[type='reset'].button--navigation, .page-banner .button--banner {
   border-radius: 5px; }
 
 .button.button--square, .file-custom .button--square.file-custom--button, button.button--square, input[type='submit'].button--square, input[type='reset'].button--square {
@@ -2178,9 +2178,9 @@ fieldset .has-warning .message li {
     input[type='reset'].button--transparent:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent:not(.button--transparent) .button--navigation:before {
       color: #FFFFFF; }
     .button.button--transparent:hover, .file-custom .button--transparent.file-custom--button:hover, .button.button--transparent:focus, .file-custom .button--transparent.file-custom--button:focus, button.button--transparent:hover, button.button--transparent:focus, input[type='submit'].button--transparent:hover, input[type='submit'].button--transparent:focus, input[type='reset'].button--transparent:hover, input[type='reset'].button--transparent:focus {
-      opacity: .6; }
+      background-color: rgba(85, 85, 85, 0.1); }
     .button.button--transparent:active, .file-custom .button--transparent.file-custom--button:active, button.button--transparent:active, input[type='submit'].button--transparent:active, input[type='reset'].button--transparent:active {
-      opacity: .9; }
+      background-color: rgba(85, 85, 85, 0.2); }
     .button.button--transparent:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
     .button.button--transparent:not(.button--icon) i.dashing-clippy:before,
     .file-custom .button--transparent.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent:not(.button--icon) .dashing-icon:before, button.button--transparent:not(.button--icon) i.dashing-tooltip:before,
@@ -2189,15 +2189,15 @@ fieldset .has-warning .message li {
     input[type='reset'].button--transparent:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent:not(.button--icon) .button--navigation:before {
       color: #3F70C9; }
     .button.button--transparent:not(.button--icon), .file-custom .button--transparent.file-custom--button:not(.button--icon), button.button--transparent:not(.button--icon), input[type='submit'].button--transparent:not(.button--icon), input[type='reset'].button--transparent:not(.button--icon) {
-      padding-left: 0;
-      padding-right: 0; }
+      padding-left: 0.5rem;
+      padding-right: 0.5rem; }
     .button.button--transparent.button--primary, .file-custom .button--transparent.button--primary.file-custom--button, button.button--transparent.button--primary, input[type='submit'].button--transparent.button--primary, input[type='reset'].button--transparent.button--primary {
       background-color: rgba(255, 255, 255, 0);
       color: #3F70C9; }
       .button.button--transparent.button--primary:hover, .file-custom .button--transparent.button--primary.file-custom--button:hover, .button.button--transparent.button--primary:focus, .file-custom .button--transparent.button--primary.file-custom--button:focus, button.button--transparent.button--primary:hover, button.button--transparent.button--primary:focus, input[type='submit'].button--transparent.button--primary:hover, input[type='submit'].button--transparent.button--primary:focus, input[type='reset'].button--transparent.button--primary:hover, input[type='reset'].button--transparent.button--primary:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--primary:active, .file-custom .button--transparent.button--primary.file-custom--button:active, button.button--transparent.button--primary:active, input[type='submit'].button--transparent.button--primary:active, input[type='reset'].button--transparent.button--primary:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--primary:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--primary:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--primary:not(.button--icon) .dashing-icon:before, button.button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before,
@@ -2209,9 +2209,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #6E6E6E; }
       .button.button--transparent.button--secondary:hover, .file-custom .button--transparent.button--secondary.file-custom--button:hover, .button.button--transparent.button--secondary:focus, .file-custom .button--transparent.button--secondary.file-custom--button:focus, button.button--transparent.button--secondary:hover, button.button--transparent.button--secondary:focus, input[type='submit'].button--transparent.button--secondary:hover, input[type='submit'].button--transparent.button--secondary:focus, input[type='reset'].button--transparent.button--secondary:hover, input[type='reset'].button--transparent.button--secondary:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--secondary:active, .file-custom .button--transparent.button--secondary.file-custom--button:active, button.button--transparent.button--secondary:active, input[type='submit'].button--transparent.button--secondary:active, input[type='reset'].button--transparent.button--secondary:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--secondary:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--secondary:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--secondary:not(.button--icon) .dashing-icon:before, button.button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before,
@@ -2223,9 +2223,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #3F70C9; }
       .button.button--transparent.button--blue:hover, .file-custom .button--transparent.button--blue.file-custom--button:hover, .button.button--transparent.button--blue:focus, .file-custom .button--transparent.button--blue.file-custom--button:focus, button.button--transparent.button--blue:hover, button.button--transparent.button--blue:focus, input[type='submit'].button--transparent.button--blue:hover, input[type='submit'].button--transparent.button--blue:focus, input[type='reset'].button--transparent.button--blue:hover, input[type='reset'].button--transparent.button--blue:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--blue:active, .file-custom .button--transparent.button--blue.file-custom--button:active, button.button--transparent.button--blue:active, input[type='submit'].button--transparent.button--blue:active, input[type='reset'].button--transparent.button--blue:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--blue:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--blue:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--blue:not(.button--icon) .dashing-icon:before, button.button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before,
@@ -2237,9 +2237,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #6E6E6E; }
       .button.button--transparent.button--gray:hover, .file-custom .button--transparent.button--gray.file-custom--button:hover, .button.button--transparent.button--gray:focus, .file-custom .button--transparent.button--gray.file-custom--button:focus, .button.button--transparent.button--grey:hover, .file-custom .button--transparent.button--grey.file-custom--button:hover, .button.button--transparent.button--grey:focus, .file-custom .button--transparent.button--grey.file-custom--button:focus, button.button--transparent.button--gray:hover, button.button--transparent.button--gray:focus, button.button--transparent.button--grey:hover, button.button--transparent.button--grey:focus, input[type='submit'].button--transparent.button--gray:hover, input[type='submit'].button--transparent.button--gray:focus, input[type='submit'].button--transparent.button--grey:hover, input[type='submit'].button--transparent.button--grey:focus, input[type='reset'].button--transparent.button--gray:hover, input[type='reset'].button--transparent.button--gray:focus, input[type='reset'].button--transparent.button--grey:hover, input[type='reset'].button--transparent.button--grey:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--gray:active, .file-custom .button--transparent.button--gray.file-custom--button:active, .button.button--transparent.button--grey:active, .file-custom .button--transparent.button--grey.file-custom--button:active, button.button--transparent.button--gray:active, button.button--transparent.button--grey:active, input[type='submit'].button--transparent.button--gray:active, input[type='submit'].button--transparent.button--grey:active, input[type='reset'].button--transparent.button--gray:active, input[type='reset'].button--transparent.button--grey:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--gray:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--gray:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--gray:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--grey:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--grey:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--grey.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
@@ -2256,9 +2256,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #09AA66; }
       .button.button--transparent.button--green:hover, .file-custom .button--transparent.button--green.file-custom--button:hover, .button.button--transparent.button--green:focus, .file-custom .button--transparent.button--green.file-custom--button:focus, button.button--transparent.button--green:hover, button.button--transparent.button--green:focus, input[type='submit'].button--transparent.button--green:hover, input[type='submit'].button--transparent.button--green:focus, input[type='reset'].button--transparent.button--green:hover, input[type='reset'].button--transparent.button--green:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--green:active, .file-custom .button--transparent.button--green.file-custom--button:active, button.button--transparent.button--green:active, input[type='submit'].button--transparent.button--green:active, input[type='reset'].button--transparent.button--green:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--green:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--green:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--green:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--green:not(.button--icon) .dashing-icon:before, button.button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before,
@@ -2270,9 +2270,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #DA3D30; }
       .button.button--transparent.button--red:hover, .file-custom .button--transparent.button--red.file-custom--button:hover, .button.button--transparent.button--red:focus, .file-custom .button--transparent.button--red.file-custom--button:focus, button.button--transparent.button--red:hover, button.button--transparent.button--red:focus, input[type='submit'].button--transparent.button--red:hover, input[type='submit'].button--transparent.button--red:focus, input[type='reset'].button--transparent.button--red:hover, input[type='reset'].button--transparent.button--red:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--red:active, .file-custom .button--transparent.button--red.file-custom--button:active, button.button--transparent.button--red:active, input[type='submit'].button--transparent.button--red:active, input[type='reset'].button--transparent.button--red:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--red:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--red:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--red:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--red:not(.button--icon) .dashing-icon:before, button.button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before,
@@ -2284,9 +2284,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #FFA11F; }
       .button.button--transparent.button--orange:hover, .file-custom .button--transparent.button--orange.file-custom--button:hover, .button.button--transparent.button--orange:focus, .file-custom .button--transparent.button--orange.file-custom--button:focus, button.button--transparent.button--orange:hover, button.button--transparent.button--orange:focus, input[type='submit'].button--transparent.button--orange:hover, input[type='submit'].button--transparent.button--orange:focus, input[type='reset'].button--transparent.button--orange:hover, input[type='reset'].button--transparent.button--orange:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--orange:active, .file-custom .button--transparent.button--orange.file-custom--button:active, button.button--transparent.button--orange:active, input[type='submit'].button--transparent.button--orange:active, input[type='reset'].button--transparent.button--orange:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--orange:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--orange:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--orange:not(.button--icon) .dashing-icon:before, button.button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before,
@@ -2298,9 +2298,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #9F65AE; }
       .button.button--transparent.button--purple:hover, .file-custom .button--transparent.button--purple.file-custom--button:hover, .button.button--transparent.button--purple:focus, .file-custom .button--transparent.button--purple.file-custom--button:focus, button.button--transparent.button--purple:hover, button.button--transparent.button--purple:focus, input[type='submit'].button--transparent.button--purple:hover, input[type='submit'].button--transparent.button--purple:focus, input[type='reset'].button--transparent.button--purple:hover, input[type='reset'].button--transparent.button--purple:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--purple:active, .file-custom .button--transparent.button--purple.file-custom--button:active, button.button--transparent.button--purple:active, input[type='submit'].button--transparent.button--purple:active, input[type='reset'].button--transparent.button--purple:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--purple:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--purple:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--purple:not(.button--icon) .dashing-icon:before, button.button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before,
@@ -2312,9 +2312,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #FFFFFF; }
       .button.button--transparent.button--white:hover, .file-custom .button--transparent.button--white.file-custom--button:hover, .button.button--transparent.button--white:focus, .file-custom .button--transparent.button--white.file-custom--button:focus, button.button--transparent.button--white:hover, button.button--transparent.button--white:focus, input[type='submit'].button--transparent.button--white:hover, input[type='submit'].button--transparent.button--white:focus, input[type='reset'].button--transparent.button--white:hover, input[type='reset'].button--transparent.button--white:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--white:active, .file-custom .button--transparent.button--white.file-custom--button:active, button.button--transparent.button--white:active, input[type='submit'].button--transparent.button--white:active, input[type='reset'].button--transparent.button--white:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--white:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--white:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--white:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .button--navigation:before, button.button--transparent.button--white:not(.button--icon) .dashing-icon:before, button.button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before,
@@ -3073,21 +3073,6 @@ span.dashing-tooltip {
     border-style: dashed; }
   .card .card--narrow {
     max-width: 750px; }
-  .card .card--list, .card .card-list {
-    margin: 0;
-    padding: 0;
-    list-style: none; }
-    .card .card--list li, .card .card-list li {
-      cursor: pointer;
-      padding: 0.75rem;
-      text-align: left;
-      -webkit-transition: all 0.15s ease-in-out;
-      -moz-transition: all 0.15s ease-in-out;
-      -o-transition: all 0.15s ease-in-out;
-      -ms-transition: all 0.15s ease-in-out;
-      transition: all 0.15s ease-in-out; }
-      .card .card--list li:hover, .card .card-list li:hover {
-        background-color: #EDEDED; }
 
 .prevent-scrolling {
   overflow: hidden; }

--- a/example/css/example.css
+++ b/example/css/example.css
@@ -930,10 +930,10 @@ corresponds to the arrow we want to display */
 
 /* Action Extendables
   =========================================================================== */
-.button, .file-custom .file-custom--button, button, input[type='submit'], input[type='reset'], .button.button--round, button.button--round, input[type='submit'].button--round, input[type='reset'].button--round {
+.button.button--round, .file-custom .button--round.file-custom--button, button.button--round, input[type='submit'].button--round, input[type='reset'].button--round {
   border-radius: 50px; }
 
-.button.button--smooth, .file-custom .button--smooth.file-custom--button, .file-custom .app-menu .app-context .app-title .file-custom--button.button--navigation, .app-menu .app-context .app-title .file-custom .file-custom--button.button--navigation, .app-menu .app-context .app-title .button.button--navigation, button.button--smooth, .app-menu .app-context .app-title button.button--navigation, input[type='submit'].button--smooth, .app-menu .app-context .app-title input[type='submit'].button--navigation, input[type='reset'].button--smooth, .app-menu .app-context .app-title input[type='reset'].button--navigation, .page-banner .button--banner {
+.button, .file-custom .file-custom--button, button, input[type='submit'], input[type='reset'], .button.button--smooth, .file-custom .app-menu .app-context .app-title .file-custom--button.button--navigation, .app-menu .app-context .app-title .file-custom .file-custom--button.button--navigation, .app-menu .app-context .app-title .button.button--navigation, button.button--smooth, .app-menu .app-context .app-title button.button--navigation, input[type='submit'].button--smooth, .app-menu .app-context .app-title input[type='submit'].button--navigation, input[type='reset'].button--smooth, .app-menu .app-context .app-title input[type='reset'].button--navigation, .page-banner .button--banner {
   border-radius: 5px; }
 
 .button.button--square, .file-custom .button--square.file-custom--button, button.button--square, input[type='submit'].button--square, input[type='reset'].button--square {
@@ -2188,9 +2188,9 @@ fieldset .has-warning .message li {
     input[type='reset'].button--transparent:not(.button--transparent) i.dashing-clippy:before, input[type='reset'].button--transparent:not(.button--transparent) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent:not(.button--transparent) .button--navigation:before, input[type='reset'].button--transparent:not(.button--transparent) .chevron-dark:before {
       color: #FFFFFF; }
     .button.button--transparent:hover, .file-custom .button--transparent.file-custom--button:hover, .button.button--transparent:focus, .file-custom .button--transparent.file-custom--button:focus, button.button--transparent:hover, button.button--transparent:focus, input[type='submit'].button--transparent:hover, input[type='submit'].button--transparent:focus, input[type='reset'].button--transparent:hover, input[type='reset'].button--transparent:focus {
-      opacity: .6; }
+      background-color: rgba(85, 85, 85, 0.1); }
     .button.button--transparent:active, .file-custom .button--transparent.file-custom--button:active, button.button--transparent:active, input[type='submit'].button--transparent:active, input[type='reset'].button--transparent:active {
-      opacity: .9; }
+      background-color: rgba(85, 85, 85, 0.2); }
     .button.button--transparent:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
     .button.button--transparent:not(.button--icon) i.dashing-clippy:before,
     .file-custom .button--transparent.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent:not(.button--icon) .chevron-dark:before, .file-custom .button--transparent.file-custom--button:not(.button--icon) .chevron-dark:before, button.button--transparent:not(.button--icon) .dashing-icon:before, button.button--transparent:not(.button--icon) i.dashing-tooltip:before,
@@ -2199,15 +2199,15 @@ fieldset .has-warning .message li {
     input[type='reset'].button--transparent:not(.button--icon) i.dashing-clippy:before, input[type='reset'].button--transparent:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title input[type='reset'].button--transparent:not(.button--icon) .button--navigation:before, input[type='reset'].button--transparent:not(.button--icon) .chevron-dark:before {
       color: #3F70C9; }
     .button.button--transparent:not(.button--icon), .file-custom .button--transparent.file-custom--button:not(.button--icon), button.button--transparent:not(.button--icon), input[type='submit'].button--transparent:not(.button--icon), input[type='reset'].button--transparent:not(.button--icon) {
-      padding-left: 0;
-      padding-right: 0; }
+      padding-left: 0.5rem;
+      padding-right: 0.5rem; }
     .button.button--transparent.button--primary, .file-custom .button--transparent.button--primary.file-custom--button, button.button--transparent.button--primary, input[type='submit'].button--transparent.button--primary, input[type='reset'].button--transparent.button--primary {
       background-color: rgba(255, 255, 255, 0);
       color: #3F70C9; }
       .button.button--transparent.button--primary:hover, .file-custom .button--transparent.button--primary.file-custom--button:hover, .button.button--transparent.button--primary:focus, .file-custom .button--transparent.button--primary.file-custom--button:focus, button.button--transparent.button--primary:hover, button.button--transparent.button--primary:focus, input[type='submit'].button--transparent.button--primary:hover, input[type='submit'].button--transparent.button--primary:focus, input[type='reset'].button--transparent.button--primary:hover, input[type='reset'].button--transparent.button--primary:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--primary:active, .file-custom .button--transparent.button--primary.file-custom--button:active, button.button--transparent.button--primary:active, input[type='submit'].button--transparent.button--primary:active, input[type='reset'].button--transparent.button--primary:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--primary:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--primary:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--primary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--primary:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--primary:not(.button--icon) .chevron-dark:before, .file-custom .button--transparent.button--primary.file-custom--button:not(.button--icon) .chevron-dark:before, button.button--transparent.button--primary:not(.button--icon) .dashing-icon:before, button.button--transparent.button--primary:not(.button--icon) i.dashing-tooltip:before,
@@ -2219,9 +2219,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #6E6E6E; }
       .button.button--transparent.button--secondary:hover, .file-custom .button--transparent.button--secondary.file-custom--button:hover, .button.button--transparent.button--secondary:focus, .file-custom .button--transparent.button--secondary.file-custom--button:focus, button.button--transparent.button--secondary:hover, button.button--transparent.button--secondary:focus, input[type='submit'].button--transparent.button--secondary:hover, input[type='submit'].button--transparent.button--secondary:focus, input[type='reset'].button--transparent.button--secondary:hover, input[type='reset'].button--transparent.button--secondary:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--secondary:active, .file-custom .button--transparent.button--secondary.file-custom--button:active, button.button--transparent.button--secondary:active, input[type='submit'].button--transparent.button--secondary:active, input[type='reset'].button--transparent.button--secondary:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--secondary:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--secondary:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--secondary:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--secondary:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--secondary:not(.button--icon) .chevron-dark:before, .file-custom .button--transparent.button--secondary.file-custom--button:not(.button--icon) .chevron-dark:before, button.button--transparent.button--secondary:not(.button--icon) .dashing-icon:before, button.button--transparent.button--secondary:not(.button--icon) i.dashing-tooltip:before,
@@ -2233,9 +2233,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #3F70C9; }
       .button.button--transparent.button--blue:hover, .file-custom .button--transparent.button--blue.file-custom--button:hover, .button.button--transparent.button--blue:focus, .file-custom .button--transparent.button--blue.file-custom--button:focus, button.button--transparent.button--blue:hover, button.button--transparent.button--blue:focus, input[type='submit'].button--transparent.button--blue:hover, input[type='submit'].button--transparent.button--blue:focus, input[type='reset'].button--transparent.button--blue:hover, input[type='reset'].button--transparent.button--blue:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--blue:active, .file-custom .button--transparent.button--blue.file-custom--button:active, button.button--transparent.button--blue:active, input[type='submit'].button--transparent.button--blue:active, input[type='reset'].button--transparent.button--blue:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--blue:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--blue:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--blue:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--blue:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--blue:not(.button--icon) .chevron-dark:before, .file-custom .button--transparent.button--blue.file-custom--button:not(.button--icon) .chevron-dark:before, button.button--transparent.button--blue:not(.button--icon) .dashing-icon:before, button.button--transparent.button--blue:not(.button--icon) i.dashing-tooltip:before,
@@ -2247,9 +2247,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #6E6E6E; }
       .button.button--transparent.button--gray:hover, .file-custom .button--transparent.button--gray.file-custom--button:hover, .file-custom .button--transparent.file-custom--button.button--sidebar-icon:hover, .button.button--transparent.button--sidebar-icon:hover, .button.button--transparent.button--gray:focus, .file-custom .button--transparent.button--gray.file-custom--button:focus, .file-custom .button--transparent.file-custom--button.button--sidebar-icon:focus, .button.button--transparent.button--sidebar-icon:focus, .button.button--transparent.button--grey:hover, .file-custom .button--transparent.button--grey.file-custom--button:hover, .button.button--transparent.button--grey:focus, .file-custom .button--transparent.button--grey.file-custom--button:focus, button.button--transparent.button--gray:hover, button.button--transparent.button--sidebar-icon:hover, button.button--transparent.button--gray:focus, button.button--transparent.button--sidebar-icon:focus, button.button--transparent.button--grey:hover, button.button--transparent.button--grey:focus, input[type='submit'].button--transparent.button--gray:hover, input[type='submit'].button--transparent.button--sidebar-icon:hover, input[type='submit'].button--transparent.button--gray:focus, input[type='submit'].button--transparent.button--sidebar-icon:focus, input[type='submit'].button--transparent.button--grey:hover, input[type='submit'].button--transparent.button--grey:focus, input[type='reset'].button--transparent.button--gray:hover, input[type='reset'].button--transparent.button--sidebar-icon:hover, input[type='reset'].button--transparent.button--gray:focus, input[type='reset'].button--transparent.button--sidebar-icon:focus, input[type='reset'].button--transparent.button--grey:hover, input[type='reset'].button--transparent.button--grey:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--gray:active, .file-custom .button--transparent.button--gray.file-custom--button:active, .file-custom .button--transparent.file-custom--button.button--sidebar-icon:active, .button.button--transparent.button--sidebar-icon:active, .button.button--transparent.button--grey:active, .file-custom .button--transparent.button--grey.file-custom--button:active, button.button--transparent.button--gray:active, button.button--transparent.button--sidebar-icon:active, button.button--transparent.button--grey:active, input[type='submit'].button--transparent.button--gray:active, input[type='submit'].button--transparent.button--sidebar-icon:active, input[type='submit'].button--transparent.button--grey:active, input[type='reset'].button--transparent.button--gray:active, input[type='reset'].button--transparent.button--sidebar-icon:active, input[type='reset'].button--transparent.button--grey:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--gray:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.file-custom--button.button--sidebar-icon:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--sidebar-icon:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--gray:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.file-custom--button.button--sidebar-icon:not(.button--icon) i.dashing-tooltip:before, .button.button--transparent.button--sidebar-icon:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--gray:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--gray.file-custom--button:not(.button--icon) i.dashing-clippy:before,
@@ -2271,9 +2271,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #09AA66; }
       .button.button--transparent.button--green:hover, .file-custom .button--transparent.button--green.file-custom--button:hover, .button.button--transparent.button--green:focus, .file-custom .button--transparent.button--green.file-custom--button:focus, button.button--transparent.button--green:hover, button.button--transparent.button--green:focus, input[type='submit'].button--transparent.button--green:hover, input[type='submit'].button--transparent.button--green:focus, input[type='reset'].button--transparent.button--green:hover, input[type='reset'].button--transparent.button--green:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--green:active, .file-custom .button--transparent.button--green.file-custom--button:active, button.button--transparent.button--green:active, input[type='submit'].button--transparent.button--green:active, input[type='reset'].button--transparent.button--green:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--green:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--green:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--green:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--green:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--green:not(.button--icon) .chevron-dark:before, .file-custom .button--transparent.button--green.file-custom--button:not(.button--icon) .chevron-dark:before, button.button--transparent.button--green:not(.button--icon) .dashing-icon:before, button.button--transparent.button--green:not(.button--icon) i.dashing-tooltip:before,
@@ -2285,9 +2285,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #DA3D30; }
       .button.button--transparent.button--red:hover, .file-custom .button--transparent.button--red.file-custom--button:hover, .button.button--transparent.button--red:focus, .file-custom .button--transparent.button--red.file-custom--button:focus, button.button--transparent.button--red:hover, button.button--transparent.button--red:focus, input[type='submit'].button--transparent.button--red:hover, input[type='submit'].button--transparent.button--red:focus, input[type='reset'].button--transparent.button--red:hover, input[type='reset'].button--transparent.button--red:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--red:active, .file-custom .button--transparent.button--red.file-custom--button:active, button.button--transparent.button--red:active, input[type='submit'].button--transparent.button--red:active, input[type='reset'].button--transparent.button--red:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--red:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--red:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--red:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--red:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--red:not(.button--icon) .chevron-dark:before, .file-custom .button--transparent.button--red.file-custom--button:not(.button--icon) .chevron-dark:before, button.button--transparent.button--red:not(.button--icon) .dashing-icon:before, button.button--transparent.button--red:not(.button--icon) i.dashing-tooltip:before,
@@ -2299,9 +2299,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #FFA11F; }
       .button.button--transparent.button--orange:hover, .file-custom .button--transparent.button--orange.file-custom--button:hover, .button.button--transparent.button--orange:focus, .file-custom .button--transparent.button--orange.file-custom--button:focus, button.button--transparent.button--orange:hover, button.button--transparent.button--orange:focus, input[type='submit'].button--transparent.button--orange:hover, input[type='submit'].button--transparent.button--orange:focus, input[type='reset'].button--transparent.button--orange:hover, input[type='reset'].button--transparent.button--orange:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--orange:active, .file-custom .button--transparent.button--orange.file-custom--button:active, button.button--transparent.button--orange:active, input[type='submit'].button--transparent.button--orange:active, input[type='reset'].button--transparent.button--orange:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--orange:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--orange:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--orange:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--orange:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--orange:not(.button--icon) .chevron-dark:before, .file-custom .button--transparent.button--orange.file-custom--button:not(.button--icon) .chevron-dark:before, button.button--transparent.button--orange:not(.button--icon) .dashing-icon:before, button.button--transparent.button--orange:not(.button--icon) i.dashing-tooltip:before,
@@ -2313,9 +2313,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #9F65AE; }
       .button.button--transparent.button--purple:hover, .file-custom .button--transparent.button--purple.file-custom--button:hover, .button.button--transparent.button--purple:focus, .file-custom .button--transparent.button--purple.file-custom--button:focus, button.button--transparent.button--purple:hover, button.button--transparent.button--purple:focus, input[type='submit'].button--transparent.button--purple:hover, input[type='submit'].button--transparent.button--purple:focus, input[type='reset'].button--transparent.button--purple:hover, input[type='reset'].button--transparent.button--purple:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--purple:active, .file-custom .button--transparent.button--purple.file-custom--button:active, button.button--transparent.button--purple:active, input[type='submit'].button--transparent.button--purple:active, input[type='reset'].button--transparent.button--purple:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--purple:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--purple:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--purple:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--purple:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--purple:not(.button--icon) .chevron-dark:before, .file-custom .button--transparent.button--purple.file-custom--button:not(.button--icon) .chevron-dark:before, button.button--transparent.button--purple:not(.button--icon) .dashing-icon:before, button.button--transparent.button--purple:not(.button--icon) i.dashing-tooltip:before,
@@ -2327,9 +2327,9 @@ fieldset .has-warning .message li {
       background-color: rgba(255, 255, 255, 0);
       color: #FFFFFF; }
       .button.button--transparent.button--white:hover, .file-custom .button--transparent.button--white.file-custom--button:hover, .button.button--transparent.button--white:focus, .file-custom .button--transparent.button--white.file-custom--button:focus, button.button--transparent.button--white:hover, button.button--transparent.button--white:focus, input[type='submit'].button--transparent.button--white:hover, input[type='submit'].button--transparent.button--white:focus, input[type='reset'].button--transparent.button--white:hover, input[type='reset'].button--transparent.button--white:focus {
-        opacity: .6; }
+        background-color: rgba(85, 85, 85, 0.1); }
       .button.button--transparent.button--white:active, .file-custom .button--transparent.button--white.file-custom--button:active, button.button--transparent.button--white:active, input[type='submit'].button--transparent.button--white:active, input[type='reset'].button--transparent.button--white:active {
-        opacity: .9; }
+        background-color: rgba(85, 85, 85, 0.2); }
       .button.button--transparent.button--white:not(.button--icon) .dashing-icon:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .dashing-icon:before, .button.button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) i.dashing-tooltip:before,
       .button.button--transparent.button--white:not(.button--icon) i.dashing-clippy:before,
       .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) i.dashing-clippy:before, .button.button--transparent.button--white:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .button.button--transparent.button--white:not(.button--icon) .button--navigation:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .app-menu .app-context .app-title .button--navigation:before, .app-menu .app-context .app-title .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .button--navigation:before, .button.button--transparent.button--white:not(.button--icon) .chevron-dark:before, .file-custom .button--transparent.button--white.file-custom--button:not(.button--icon) .chevron-dark:before, button.button--transparent.button--white:not(.button--icon) .dashing-icon:before, button.button--transparent.button--white:not(.button--icon) i.dashing-tooltip:before,
@@ -3108,21 +3108,6 @@ span.dashing-tooltip {
     border-style: dashed; }
   .card .card--narrow {
     max-width: 750px; }
-  .card .card--list, .card .card-list {
-    margin: 0;
-    padding: 0;
-    list-style: none; }
-    .card .card--list li, .card .card-list li {
-      cursor: pointer;
-      padding: 0.75rem;
-      text-align: left;
-      -webkit-transition: all 0.15s ease-in-out;
-      -moz-transition: all 0.15s ease-in-out;
-      -o-transition: all 0.15s ease-in-out;
-      -ms-transition: all 0.15s ease-in-out;
-      transition: all 0.15s ease-in-out; }
-      .card .card--list li:hover, .card .card-list li:hover {
-        background-color: #EDEDED; }
 
 .prevent-scrolling {
   overflow: hidden; }
@@ -5441,7 +5426,7 @@ pre.line-numbers > code {
     display: block; }
 
 h2 .button--copy-link {
-  width: 100px;
+  width: auto;
   pointer-events: initial;
   transition: all 0.25s;
   opacity: 1;
@@ -5456,7 +5441,7 @@ h2 .button--copy-link {
       pointer-events: none;
       opacity: 0; } }
 h2:hover .button--copy-link, h2:active .button--copy-link {
-  width: 100px;
+  width: auto;
   pointer-events: initial;
   opacity: 1; }
   h2:hover .button--copy-link:active, h2:hover .button--copy-link:focus, h2:active .button--copy-link:active, h2:active .button--copy-link:focus {

--- a/example/css/example.css
+++ b/example/css/example.css
@@ -3108,6 +3108,21 @@ span.dashing-tooltip {
     border-style: dashed; }
   .card .card--narrow {
     max-width: 750px; }
+  .card .card--list, .card .card-list {
+    margin: 0;
+    padding: 0;
+    list-style: none; }
+    .card .card--list li, .card .card-list li {
+      cursor: pointer;
+      padding: 0.75rem;
+      text-align: left;
+      -webkit-transition: all 0.15s ease-in-out;
+      -moz-transition: all 0.15s ease-in-out;
+      -o-transition: all 0.15s ease-in-out;
+      -ms-transition: all 0.15s ease-in-out;
+      transition: all 0.15s ease-in-out; }
+      .card .card--list li:hover, .card .card-list li:hover {
+        background-color: #EDEDED; }
 
 .prevent-scrolling {
   overflow: hidden; }

--- a/example/sass/example.scss
+++ b/example/sass/example.scss
@@ -113,7 +113,7 @@ h2 {
     &:after {
       content: "Copy Link";
     }
-      width: 100px;
+      width: auto;
       pointer-events: initial;
       transition: all 0.25s;
       opacity: 1;
@@ -138,7 +138,7 @@ h2 {
           }
           color: $green-500;
         }
-      width: 100px;
+      width: auto;
       pointer-events: initial;
       // transition: all 0.5s;
       opacity: 1;

--- a/example/templates/cards/index.html
+++ b/example/templates/cards/index.html
@@ -335,35 +335,6 @@
 </div>
 </div>
 
-<div class="row">
-  <div class="column column--full">
-    <h2 class="example-header">Card List <button class="button button--transparent button--copy-link" data-id="copyurl" id="Card_List"></button></h2>
-    <div class="row example-container">
-      <div class="column column--full">
-        <div class="card" style="overflow: hidden;" data-id="need">
-          <ul class="card--list">
-            <li>Ryan Fitz</li>
-            <li>Jill Fitz</li>
-            <li>Jackson Fitz</li>
-            <li>Emily Fitz</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-<div class="code-toggle"><i class="icon--code"></i></div>
-<pre><code class="language-html">&lt;div class="card card--dashed"&gt;
-  &lt;div class="card--header"&gt;
-    &lt;h3&gt;This is a dashed card&lt;/h3&gt;
-  &lt;/div&gt;
-
-  &lt;div class="card--content"&gt;
-    &lt;p class="remove-margin--top"&gt;To use a dashed card, apply &lt;code class="example-text"&gt;.card--dashed&lt;/code&gt; after &lt;code class="example-text"&gt;.card&lt;/code&gt;.&lt;/p&gt;
-  &lt;/div&gt;
-&lt;/div&gt;</code>
-</pre>
-</div>
-</div>
-
     </div>
   </body>
 </html>

--- a/example/templates/cards/index.html
+++ b/example/templates/cards/index.html
@@ -126,7 +126,6 @@
           </div>
         </div>
       </div>
-    </div>
 <div class="code-toggle"><i class="icon--code"></i></div>
 <pre><code class="language-html">&lt;div class="card"&gt;
   &lt;div class="card--header has-border"&gt;
@@ -331,6 +330,35 @@
       &lt;button class="button button--secondary button--transparent"&gt;Cancel&lt;/button&gt;
     &lt;/div&gt;
   &lt;/form&gt;
+&lt;/div&gt;</code>
+</pre>
+</div>
+</div>
+
+<div class="row">
+  <div class="column column--full">
+    <h2 class="example-header">Card List <button class="button button--transparent button--copy-link" data-id="copyurl" id="Card_List"></button></h2>
+    <div class="row example-container">
+      <div class="column column--full">
+        <div class="card" style="overflow: hidden;" data-id="need">
+          <ul class="card--list">
+            <li>Ryan Fitz</li>
+            <li>Jill Fitz</li>
+            <li>Jackson Fitz</li>
+            <li>Emily Fitz</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+<div class="code-toggle"><i class="icon--code"></i></div>
+<pre><code class="language-html">&lt;div class="card card--dashed"&gt;
+  &lt;div class="card--header"&gt;
+    &lt;h3&gt;This is a dashed card&lt;/h3&gt;
+  &lt;/div&gt;
+
+  &lt;div class="card--content"&gt;
+    &lt;p class="remove-margin--top"&gt;To use a dashed card, apply &lt;code class="example-text"&gt;.card--dashed&lt;/code&gt; after &lt;code class="example-text"&gt;.card&lt;/code&gt;.&lt;/p&gt;
+  &lt;/div&gt;
 &lt;/div&gt;</code>
 </pre>
 </div>

--- a/sass/base/mixins/_mixins.scss
+++ b/sass/base/mixins/_mixins.scss
@@ -91,8 +91,8 @@
 @mixin transparent--button($color) {
   background-color: transparentize(white, 1);
   color: $color;
-  &:hover, &:focus { opacity: .6; }
-  &:active { opacity: .9; }
+  &:hover, &:focus { background-color: rgba(85,85,85,.1) }
+  &:active { background-color: rgba(85,85,85,.2) }
   &:not(.button--icon) .dashing-icon:before { color: $color; }
 }
 

--- a/sass/modules/actions/_actions.scss
+++ b/sass/modules/actions/_actions.scss
@@ -26,7 +26,7 @@ $button-disabled: "&[disabled], &.disabled, &.button--disabled";
   =========================================================================== */
 #{$buttons} {
   @extend %action;
-  @extend %button--round;
+  @extend %button--smooth;
   @include button($background-color: $blue, $color: $white);
 
   -webkit-font-smoothing: auto;
@@ -85,8 +85,8 @@ $button-disabled: "&[disabled], &.disabled, &.button--disabled";
     @include button($background-color: transparentize(white, 1), $color: $blue);
     @include transparent--button($color: $blue);
     &:not(.button--icon) { //Retains button--icon padding
-      padding-left: 0;
-      padding-right: 0;
+      padding-left: 0.5rem;
+      padding-right: 0.5rem;
     }
 
     &.button--primary { @include transparent--button($color: $blue); }

--- a/sass/modules/card/_card.scss
+++ b/sass/modules/card/_card.scss
@@ -79,25 +79,4 @@
   .card--narrow{
     max-width: 750px;
   }
-
-  .card--list, .card-list {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-
-    li {
-      cursor: pointer;
-      padding: 0.75rem;
-      text-align: left;
-      -webkit-transition: all 0.15s ease-in-out;
-      -moz-transition: all 0.15s ease-in-out;
-      -o-transition: all 0.15s ease-in-out;
-      -ms-transition: all 0.15s ease-in-out;
-      transition: all 0.15s ease-in-out;
-
-      &:hover {
-        background-color: $gray-100;
-      }
-    }
-  }
 }

--- a/sass/modules/card/_card.scss
+++ b/sass/modules/card/_card.scss
@@ -79,4 +79,25 @@
   .card--narrow{
     max-width: 750px;
   }
+
+  .card--list, .card-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    li {
+      cursor: pointer;
+      padding: 0.75rem;
+      text-align: left;
+      -webkit-transition: all 0.15s ease-in-out;
+      -moz-transition: all 0.15s ease-in-out;
+      -o-transition: all 0.15s ease-in-out;
+      -ms-transition: all 0.15s ease-in-out;
+      transition: all 0.15s ease-in-out;
+
+      &:hover {
+        background-color: $gray-100;
+      }
+    }
+  }
 }


### PR DESCRIPTION
I'd like to propose an update to transparent button styles by adding a subtle background color on hover and focus. This seems to be standard for other transparent button styles throughout the industry, and seems to increase usability by 

<img width="469" alt="screen shot 2018-08-27 at 12 14 17 pm" src="https://user-images.githubusercontent.com/7129122/44674450-26543500-a9f3-11e8-855c-84c3c475009f.png">
